### PR TITLE
Update see-change-and-reset-a-conference-id-assigned-to-a-user.md

### DIFF
--- a/Skype/SfbOnline/audio-conferencing-in-office-365/see-change-and-reset-a-conference-id-assigned-to-a-user.md
+++ b/Skype/SfbOnline/audio-conferencing-in-office-365/see-change-and-reset-a-conference-id-assigned-to-a-user.md
@@ -90,7 +90,7 @@ You can reset a conference ID for a user if, for example, if they forget it.
     You can reset the conference ID for a user by using the Windows PowerShell. To do this, run:
     
   ```
-  Set-CsOnlineDialInConferencingUser -Identity "Amos Marble"  -ResetLeaderPIN 8271964
+  Set-CsOnlineDialInConferencingUser -Identity "Amos Marble"  -ResetConferenceID 8271964
   ```
 
 ## What else should you know?


### PR DESCRIPTION
With the move in Skype for Business Online to default to dynamic conference IDs at a tenant level in late 2016, customers are unable to configure a static conference ID for a user. Trying to push a Set-CsOnlineDialInConferencing to a user to force a ConferenceID (for static) will initially display a result indicating this was applied. However, running a Get-CsOnlineDialInConferencing subsequently indicates we still resolve as a 0 (dynamic). Only tenants that are configured for static at a tenant level, rather than dynamic, can change this. In changing to dynamic as the default in late 2016, the only option to swap back was on a case-by-case basis. That process is no longer supported as of early 2018. This would mean that this article would only apply to legacy tenants in Skype for Business Online configured for static by default (rather than dynamic).

I've made no changes to the article to reflect the above and will defer to your judgement how best to represent this. Maybe a flash at the top indicating this only applies to legacy tenants configured for static. I did correct the "To reset the conference ID" cmdlet to reflect the -ResetConferenceID rather than -ResetLeaderPIN as these serve a different purpose.

If I can help at all on the above, please let me know.
