### PR TITLE
Need to edit out any Static information

### DIFF
--- a/Skype/SfbOnline/audio-conferencing-in-office-365/manage-the-audio-conferencing-settings-for-my-organization.md
+++ b/Skype/SfbOnline/audio-conferencing-in-office-365/manage-the-audio-conferencing-settings-for-my-organization.md
@@ -50,22 +50,7 @@ It might be easier for you to see all of the audio conferencing settings for Sky
   
 ## Assign a conference ID for a user
 
-A conference ID is automatically assigned to a user when they are set up for audio conferencing using Microsoft as the audio conferencing provider. The conference ID assigned can be either static or dynamic and is sent in the meeting invite when the meeting is scheduled. 
-  
-Static IDs are used when people in your organization don't want to remember a random number; they can select a certain number or choose one that's easy to remember. When dynamic conference IDs are used, each meeting that a user schedules will get assigned a unique conference ID. If you want to assign dynamic rather than static conference IDs, see [Using Audio Conferencing dynamic IDs in your organization](using-audio-conferencing-dynamic-ids-in-your-organization.md).
-  
-The Skype for Business admin center can't be used to assign a conference ID to a user, but you can use the Windows PowerShell cmdlet to do this.
-  
-To set the conference ID for a user, run:
-  
-```
-Set-CsOnlineDialInConferencingUser -Identity "Amos Marble"  -ConferenceId 8271964 
-```
-
-> [!IMPORTANT]
-> A conference ID must contain 7 digits, and you can't change it in the Skype for Business admin center or by using Windows PowerShell. 
-  
-See [Set-CsOnlineDialInConferencingUser](https://go.microsoft.com/fwlink/?LinkId=617688 ) to learn more about the cmdlet.
+We no longer support the use of IDs, so your users will only be able to leverage dynamic ID's for their primary conference ID utilization.
   
 > [!IMPORTANT]
 >  After a new conference ID is created, the old conference ID can't be used by callers. You should notify users to reschedule their existing meeting invites to make sure the new conference ID is added to the invitations. The users can use the Skype for Business Meeting Migration Tool to update their existing meetings. To see how to download, install, and run the Skype for Business Meeting Update Tool, see: [Meeting Update Tool for Skype for Business and Lync](https://support.office.com/article/2b525fe6-ed0f-4331-b533-c31546fcf4d4), [Skype for Business Online, Meeting Migration Tool (64-bit)](http://go.microsoft.com/fwlink/?LinkID=626047), and  [Skype for Business Online, Meeting Migration Tool (32-bit)](https://www.microsoft.com/en-us/download/details.aspx?id=54079).
@@ -156,10 +141,6 @@ See [Emails that are automatically sent to users when their Audio Conferencing s
 See [Reset a conference ID for a user](reset-a-conference-id-for-a-user.md).
   
 ## Reset a conference organizer's PIN
-
-Static IDs are used when people in your organization don't want to remember a random number; they can select a certain number or use one that's easy to remember. When dynamic conference IDs are used, each meeting that a user schedules will get assigned a unique conference ID. If you want to assign dynamic rather than static conference IDs, [Using Audio Conferencing dynamic IDs in your organization](using-audio-conferencing-dynamic-ids-in-your-organization.md).
-  
-Although a static conference ID will be automatically created and assigned to a user, there may be times when a user doesn't want to use this one and you want to set it to a certain number, or your users can't remember or have lost their conference ID. You can use the Skype for Business admin center and Windows PowerShell to view, change, and reset their conference ID.
   
 1. Sign in to Office 365 with your work or school account.
     


### PR DESCRIPTION
SfB & Teams no longer support the use of Static IDs and we're getting support calls because of this article. Need to clear out/clean up the conference articles that reference Static IDs.