### PR TITLE
 $setting["EnableGroupCreation"] = "true"

### DIFF
--- a/Teams/assign-roles-permissions.md
+++ b/Teams/assign-roles-permissions.md
@@ -85,7 +85,7 @@ Set-MsolCompanySettings -UsersPermissionToCreateGroupsEnabled $True
 
     $Setting = $template.CreateDirectorySetting()
 
-    $setting["EnableGroupCreation"] = "false"
+    $setting["EnableGroupCreation"] = "true"
 
     $setting["GroupCreationAllowedGroupId"] = "&lt;ObjectId of Group Allowed to Create Groups>"
 


### PR DESCRIPTION
It looks like there is a typo in the line 88 where  $setting["EnableGroupCreation"]  is set to "false".
Shouldn't it be  $setting["EnableGroupCreation"] = "true" instead?