### PR TITLE
Tidy up PowerShell script for Teams clean up

### DIFF
--- a/Teams/scripts/Powershell-script-teams-deployment-clean-up.md
+++ b/Teams/scripts/Powershell-script-teams-deployment-clean-up.md
@@ -31,19 +31,19 @@ $TeamsUpdateExePath = [System.IO.Path]::Combine($env:LOCALAPPDATA, 'Microsoft', 
 
 try
 {
-    if ([System.IO.File]::Exists($TeamsUpdateExePath)) {
+    if (Test-Path -Path $TeamsUpdateExePath) {
         Write-Host "Uninstalling Teams process"
 
         # Uninstall app
-        $proc = Start-Process $TeamsUpdateExePath "-uninstall -s" -PassThru
+        $proc = Start-Process -FilePath $TeamsUpdateExePath -ArgumentList "-uninstall -s" -PassThru
         $proc.WaitForExit()
     }
     Write-Host "Deleting Teams directory"
-    Remove-Item –path $TeamsPath -recurse
+    Remove-Item –Path $TeamsPath -Recurse
 }
 catch
 {
-    Write-Output "Uninstall failed with exception $_.exception.message"
+    Write-Error -ErrorRecord $_
     exit /b 1
 }
 


### PR DESCRIPTION
Use full parameter names where possible to ensure readability and maintainability by many users. 
Use Test-Path instead of [System.Io.Path], again for readability. Leave the Combine methods in place as they are more readable than the alternative approach of nested Join-Path calls.
Change Write-Output in the catch block to Write-Error. Write-Output should only be used to pass things along the pipeline, for other information output there are a number of other streams for use and Write-Error is the most applicable here. There is a case for using Write-Warning instead for user interaction purposes, since many users are less likely to read the red text that Write-Error defaults to, but that doesn't quite fit with what the cmdlet does as the information it would be relaying is an error and not a warning.