### PR TITLE
FIxed HA Terminology

### DIFF
--- a/Skype/SfbServer/deploy/deploy-high-availability-and-disaster-recovery/alwayson-availability-group.md
+++ b/Skype/SfbServer/deploy/deploy-high-availability-and-disaster-recovery/alwayson-availability-group.md
@@ -1,5 +1,5 @@
 ---
-title: "Deploy an AlwaysOn Availability Group on a Back End Server in Skype for Business Server 2015"
+title: "Deploy an Always On Availability Group on a Back End Server in Skype for Business Server 2015"
 ms.author: heidip
 author: microsoftheidi
 manager: serdars
@@ -10,31 +10,28 @@ ms.prod: skype-for-business-itpro
 localization_priority: Normal
 ms.collection: IT_Skype16
 ms.assetid: c93c01e6-626c-40ad-92dd-373b0fe9189f
-description: "Deploy (install) an AlwaysOn Availability Group in your Skype for Business Server deployment."
+description: "Deploy (install) an Always On Availability Group in your Skype for Business Server deployment."
 ---
 
-# Deploy an AlwaysOn Availability Group on a Back End Server in Skype for Business Server 2015
+# Deploy an Always On Availability Group on a Back End Server in Skype for Business Server 2015
  
-Deploy (install) an AlwaysOn Availability Group in your Skype for Business Server deployment.
+Deploy (install) an Always On Availability Group (AG) in your Skype for Business Server deployment.
   
-How you deploy an AlwaysOn Availability Group depends on whether you are deploying it in a new pool, an existing pool that uses mirroring, or an existing pool that currently has no high availability for the Back End database.
+How you deploy an AG depends on whether you are deploying it in a new pool, an existing pool that uses mirroring, or an existing pool that currently has no high availability for the Back End database.
   
 > [!NOTE]
-> Using an AlwaysOn Availability Group with a Persistent Chat Server role is not supported. 
+> Using an AG with a Persistent Chat Server role is not supported. 
   
-> [!IMPORTANT]
-> Instance names for multiple AlwaysOn Availability Group instances must be the same. 
-  
-- [Deploy an AlwaysOn Availability Group on a new Front End pool](alwayson-availability-group.md#BKMK_NewPool_CreateAlwaysOnGroup)
+- [Deploy an Always On Availability Group on a new Front End pool](alwayson-availability-group.md#BKMK_NewPool_CreateAlwaysOnGroup)
     
-- [Deploy an AlwaysOn Availability Group on an existing pool that uses database mirroring](alwayson-availability-group.md#BKMK_MirroredPool_CreateAlwaysOnGroup)
+- [Deploy an Always On Availability Group on an existing pool that uses database mirroring](alwayson-availability-group.md#BKMK_MirroredPool_CreateAlwaysOnGroup)
     
-- [Deploy an AlwaysOn Availability Group on an existing pool that does not use database mirroring](alwayson-availability-group.md#BKMK_NoHAPool_CreateAlwaysOnGroup)
+- [Deploy an Always On Availability Group on an existing pool that does not use database mirroring](alwayson-availability-group.md#BKMK_NoHAPool_CreateAlwaysOnGroup)
     
-## Deploy an AlwaysOn Availability Group on a new Front End pool
+## Deploy an Always On Availability Group on a new Front End pool
 <a name="BKMK_NewPool_CreateAlwaysOnGroup"> </a>
 
-1. Set up Windows Server Failover Clustering on all the database servers which will be part of the AlwaysOn Availability Group. On each server, do the following
+1. Enable the Failover Clustering feature on all the database servers which will be part of the AG. On each server, do the following
     
    - Open Server Manager and click **Add roles and features**.
     
@@ -58,7 +55,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
     The wizard will probably report several warnings, especially if you are not using shared storage. You are not required to use shared storage. However, if you see any **Error** messages, you must fix those issues before continuing.
     
-3. Create the cluster.
+3. Create the Windows Server Failover Cluster (WSFC).
     
    - In the **Failover Cluster Management** wizard, right-click **Failover Cluster Management**, then click **Create Cluster**.
     
@@ -82,7 +79,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - On the **Confirmation** page, click **Next**.
     
-5. On each server in the cluster, enable Always On in SQL Server Configuration Manager.
+5. On each server in the cluster, enable the AG feature in SQL Server Configuration Manager.
     
    - Open SQL Server Configuration Manager. In the tree on the left side of the screen, click **SQL Server Services**, then double-click the SQL Server service. 
     
@@ -92,7 +89,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - Open SQL Server Management Studio, and connect to the SQL Server instance.
     
-   - In Object Explorer, expand the **AlwaysOn High Availability** folder. Right-click the **Availability Groups** folder and click **New Availability Group Wizard**.
+   - In Object Explorer, expand the **Always On High Availability** folder. Right-click the **Availability Groups** folder and click **New Availability Group Wizard**.
     
    - If the **Introduction** page appears, click **Next**.
     
@@ -120,19 +117,19 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - In the**Summary** page, verify all settings and click Finish.
     
-7. Use Topology Builder to create the Front End pool, as explained in [Create and publish new topology in Skype for Business Server 2015](../../deploy/install/create-and-publish-new-topology.md). When you do, specify the AlwaysOn Availability Group as the SQL store for the pool.
+7. Use Topology Builder to create the Front End pool, as explained in [Create and publish new topology in Skype for Business Server 2015](../../deploy/install/create-and-publish-new-topology.md). When you do, specify the AG as the SQL store for the pool.
     
-8. After the pool and the AlwaysOn Availability Group are deployed, perform some final steps to make sure that the SQL logins are on each of the replicas in the AlwaysOn Availability Group. 
+8. After the pool and the AG are deployed, perform some final steps to make sure that the SQL logins are on each of the replicas in the AlwaysOn Availability Group. 
     
    - Open Topology Builder, select **Download topology from existing deployment**, and click **OK**.
     
    - Expand Skype for Business Server, expand your topology, and expand **SQL Server Stores**. Right-click the SQL store of the new AlwaysOn Availability Group, and click ** Edit Properties**.
     
-    - At the bottom of the page, in the **SQL Server FQDN** box, change the value to the FQDN of the Listener of the AlwaysOn Availability Group.
+    - At the bottom of the page, in the **SQL Server FQDN** box, change the value to the FQDN of the Listener of the AG.
     
    - Publish the topology. From the **Action** menu click **Topology** and then **Publish**. Then in the confirmation page click **Next**. Then wait a few minutes for the new topology to replicate.
     
-   - Open SQL Server Management Studio, and navigate to the AlwaysOn Availability Group. Fail it over to a secondary replica.
+   - Open SQL Server Management Studio, and navigate to the AG. Fail it over to a secondary replica.
     
    - Open Skype for Business Server Management Shell and type the following cmdlet to create the SQL logins on this replica:
     
@@ -142,11 +139,11 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
 
    - Repeat the previous two steps (fail over the group to a secondary replica, then use  `Install-CsDatabase -Update`) for each replica in the group.
     
-## Deploy an AlwaysOn Availability Group on an existing pool that uses database mirroring
+## Deploy an Always On Availability Group on an existing pool that uses database mirroring
 <a name="BKMK_MirroredPool_CreateAlwaysOnGroup"> </a>
 
 > [!NOTE]
-> If the pool you are upgrading to an AlwaysOn Availability Group hosts the Central Management store for your organization, you must first move the CMS to another pool before you upgrade this pool. Use the Move-CsManagementServer cmdlet to move the pool. If you do not have another pool in your organization, you can deploy a Standard Edition server temporarily and move the CMS to this server before you upgrade your pool to the AlwaysOn Availability Group. 
+> If the pool you are upgrading to an AG hosts the Central Management store for your organization, you must first move the CMS to another pool before you upgrade this pool. Use the Move-CsManagementServer cmdlet to move the pool. If you do not have another pool in your organization, you can deploy a Standard Edition server temporarily and move the CMS to this server before you upgrade your pool to the AG. 
   
 1. Fail over all data from the mirror to the principal node by opening Skype for Business Server Management Shell and typing the following cmdlet.
     
@@ -172,9 +169,9 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - Open SQL Server Management Studio, navigate to your databases, right-click **Tasks** and click **Mirror**. Then click **Remove Mirroring** and click **OK**.
     
-   - Repeat this for all databases in the pool which will be converted to an AlwaysOn Availability Group.
+   - Repeat this for all databases in the pool which will be converted to an AG.
     
-5. Set up Windows Server Failover Clustering on all the database servers which will be part of the AlwaysOn Availability Group. On each server, do the following
+5. Set up the Failover Clustering feature on all the database servers which will be part of the AG. On each server, do the following
     
    - Open Server Manager and click **Add roles and features**.
     
@@ -198,7 +195,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
     The wizard will probably report several warnings, especially if you are not using shared storage. You are not required to use shared storage. However, if you see any **Error** messages, you must fix those issues before continuing.
     
-7. Create the cluster.
+7. Create the Windows Server Failover Cluster.
     
    - In the **Failover Cluster Management** wizard, right-click **Failover Cluster Management**, then click **Create Cluster**.
     
@@ -222,7 +219,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - On the **Confirmation** page, click **Next**.
     
-9. On each server in the cluster, enable Always On in SQL Server Configuration Manager.
+9. On each server in the cluster, enable the AG feature in SQL Server Configuration Manager.
     
    - Open SQL Server Configuration Manager. In the tree on the left side of the screen, click **SQL Server Services**, then double-click the SQL Server service. 
     
@@ -232,7 +229,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
     - Open SQL Server Management Studio, and connect to the SQL Server instance.
     
-    - In Object Explorer, expand the **AlwaysOn High Availability** folder. Right-click the **Availability Groups** folder and click **New Availability Group Wizard**.
+    - In Object Explorer, expand the **Always On High Availability** folder. Right-click the **Availability Groups** folder and click **New Availability Group Wizard**.
     
     - If the **Introduction** page appears, click **Next**.
     
@@ -260,7 +257,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
     - In the **Summary** page, verify all settings and click Finish.
     
-11. Create a new store specifying the AlwaysOn Availability Group listener, and specifying the principal of the old mirror as the primary node of the AlwaysOn Availability Group.
+11. Create a new store specifying the AG listener, and specifying the principal of the old mirror as the primary node of the AG.
     
     - Open Topology Builder. In your topology, expand **Shared Components**, right-click **SQL Server Stores**, and click **New SQL Server Store**.
     
@@ -268,15 +265,15 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
     - In the **SQL Server Availability Listener FQDN** box, type the FQDN of the listener you created when you created the availability group.
     
-    - In the **SQL Server FQDN** box, type the FQDN of the primary node of the AlwaysOn Availability Group, and then click **OK**. This should be the principal of the old mirror for this store.
+    - In the **SQL Server FQDN** box, type the FQDN of the primary node of the AG, and then click **OK**. This should be the principal of the old mirror for this store.
     
-12. Associate the new AlwaysOn Availability Group with the Front End pool.
+12. Associate the new AG with the Front End pool.
     
-    - In Topology Builder, right-click the pool to associate with the AlwaysOn Availability Group, and click **Edit Properties**.
+    - In Topology Builder, right-click the pool to associate with the AG, and click **Edit Properties**.
     
-    - Under **Associations**, in the **SQL Server Store** box, select the AlwaysOn Availability Group. Select the same group for any other databases in the pool which you want to move to the AlwaysOn Availability Group.
+    - Under **Associations**, in the **SQL Server Store** box, select the AG. Select the same group for any other databases in the pool which you want to move to the AG.
     
-    - When you're sure that all needed databases are set to the AlwaysOn Availability Group, click **OK**.
+    - When you're sure that all needed databases are set to the AG, click **OK**.
     
 13. Publish the topology. From the **Action** menu click **Topology** and then **Publish**. Then in the confirmation page click **Next**.
     
@@ -284,13 +281,13 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
     - Open Topology Builder, select **Download topology from existing deployment**, and click **OK**.
     
-    - Expand Skype for Business Server, expand your topology, and expand **SQL Server Stores**. Right-click the SQL store of the new AlwaysOn Availability Group, and click **Edit Properties**.
+    - Expand Skype for Business Server, expand your topology, and expand **SQL Server Stores**. Right-click the SQL store of the new AG, and click **Edit Properties**.
     
-    - At the bottom of the page, in the **SQL Server FQDN** box, change the value to the FQDN of the Listener of the AlwaysOn Availability Group.
+    - At the bottom of the page, in the **SQL Server FQDN** box, change the value to the FQDN of the Listener of the AG.
     
     - Publish the topology. From the **Action** menu click **Topology** and then **Publish**. Then in the confirmation page click **Next**. Then wait a few minutes for the new topology to replicate.
     
-    - Open SQL Server Management Studio, and navigate to the AlwaysOn Availability Group. Fail it over to a secondary replica.
+    - Open SQL Server Management Studio, and navigate to the AG. Fail it over to a secondary replica.
     
     - Open Skype for Business Server Management Shell and type the following cmdlet to create the SQL logins on this replica:
     
@@ -300,13 +297,13 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
 
     - Repeat the previous two steps (fail over the group to a secondary replica, then use  `Install-CsDatabase -Update`) for each replica in the group.
     
-## Deploy an AlwaysOn Availability Group on an existing pool that does not use database mirroring
+## Deploy an Always On Availability Group on an existing pool that does not use database mirroring
 <a name="BKMK_NoHAPool_CreateAlwaysOnGroup"> </a>
 
 > [!NOTE]
-> If the pool you are upgrading to an AlwaysOn Availability Group hosts the Central Management store for your organization, you must first move the CMS to another pool before you upgrade this pool. Use the Move-CsManagementServer cmdlet to move the pool. If you do not have another pool in your organization, you can deploy a Standard Edition server temporarily and move the CMS to this server before you upgrade your pool to the AlwaysOn Availability Group. 
+> If the pool you are upgrading to an AG hosts the Central Management store for your organization, you must first move the CMS to another pool before you upgrade this pool. Use the Move-CsManagementServer cmdlet to move the pool. If you do not have another pool in your organization, you can deploy a Standard Edition server temporarily and move the CMS to this server before you upgrade your pool to the AG. 
   
-1. Set up Windows Server Failover Clustering on all the database servers which will be part of the AlwaysOn Availability Group. On each server, do the following
+1. Set up the Failover Clustering feature on all the database servers which will be part of the AG. On each server, do the following
     
    - Open Server Manager and click **Add roles and features**.
     
@@ -330,7 +327,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
     The wizard will probably report several warnings, especially if you are not using shared storage. You are not required to use shared storage. However, if you see any **Error** messages, you must fix those issues before continuing.
     
-3. Create the cluster.
+3. Create the Windows Server Failover Cluster (WSFC).
     
    - In the **Failover Cluster Management** wizard, right-click **Failover Cluster Management**, then click **Create Cluster**.
     
@@ -354,7 +351,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - On the **Confirmation** page, click **Next**.
     
-5. On each server in the cluster, enable Always On in SQL Server Configuration Manager.
+5. On each server in the cluster, enable AG in SQL Server Configuration Manager.
     
    - Open SQL Server Configuration Manager. In the tree on the left side of the screen, click **SQL Server Services**, then double-click the SQL Server service. 
     
@@ -364,17 +361,17 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - Open SQL Server Management Studio, and connect to the SQL Server instance.
     
-   - In Object Explorer, expand the **AlwaysOn High Availability** folder. Right-click the **Availability Groups** folder and click **New Availability Group Wizard**.
+   - In Object Explorer, expand the **Always On High Availability** folder. Right-click the **Availability Groups** folder and click **New Availability Group Wizard**.
     
    - If the **Introduction** page appears, click **Next**.
     
    - In the **Specify Availability Group Name** page, type the name of the Availability group, and click **Next**.
     
-   - In the Select Databases page, select the databases that you want to include in the AlwaysOn Availability Group. Then click **Next**.
+   - In the Select Databases page, select the databases that you want to include in the AG. Then click **Next**.
     
-    Do not include the **ReportServer**, **ReportServerTempDB**, or Persistent Chat databases in the AlwaysOn Availability Group, as these are not supported in this scenario. You can include all other Skype for Business Server databases in the AlwaysOn Availability Group.
+    Do not include the **ReportServer**, **ReportServerTempDB**, or Persistent Chat databases in the AG, as these are not supported in this scenario. You can include all other Skype for Business Server databases in the AG.
     
-   - In the **Specify Replicas** page, click the **Replicas** tab. Then click the **Add Replicas** button, and connect to the other SQL instances that you joined as nodes of the Windows Server Failover Cluster.
+   - In the **Specify Replicas** page, click the **Replicas** tab. Then click the **Add Replicas** button, and connect to the other SQL instances that you joined as nodes of the WSFC.
     
    - For each instance, select the **Automatic Failover** and **Synchronous Commit** options. Do not select the **Readable Secondary** option.
     
@@ -392,7 +389,7 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - In the **Summary** page, verify all settings and click Finish.
     
-7. Create a new store specifying the AlwaysOn Availability Group listener.
+7. Create a new store specifying the AG listener.
     
    - Open Topology Builder. In your topology, expand **Shared Components**, right-click **SQL Server Stores**, and click **New SQL Server Store**.
     
@@ -400,29 +397,29 @@ How you deploy an AlwaysOn Availability Group depends on whether you are deployi
     
    - In the **SQL Server Availability Listener FQDN** box, type the FQDN of the listener you created when you created the availability group.
     
-   - In the **SQL Server FQDN** box, type the FQDN of the primary node of the AlwaysOn Availability Group, and then click **OK**.
+   - In the **SQL Server FQDN** box, type the FQDN of the primary node of the AG, and then click **OK**.
     
-8. Associate the new AlwaysOn Availability Group with the Front End pool.
+8. Associate the new Always On Availability Group with the Front End pool.
     
-   - In Topology Builder, right-click the pool to associate with the AlwaysOn Availability Group, and click **Edit Properties**.
+   - In Topology Builder, right-click the pool to associate with the AG, and click **Edit Properties**.
     
-   - Under **Associations**, in the **SQL Server Store** box, select the AlwaysOn Availability Group. Select the same group for any other databases in the pool which you want to move to the AlwaysOn Availability Group.
+   - Under **Associations**, in the **SQL Server Store** box, select the AG. Select the same group for any other databases in the pool which you want to move to the AG.
     
-   - When you're sure that all needed databases are set to the AlwaysOn Availability Group, click **OK**.
+   - When you're sure that all needed databases are set to the AG, click **OK**.
     
 9. Publish the topology. From the **Action** menu click **Topology** and then **Publish**. Then in the confirmation page click **Next**.
     
-10. Perform some final steps to make sure that the SQL logins are on each of the replicas in the AlwaysOn Availability Group.
+10. Perform some final steps to make sure that the SQL logins are on each of the replicas in the AG.
     
     - Open Topology Builder, select **Download topology from existing deployment**, and click **OK**.
     
-    - Expand Skype for Business Server, expand your topology, and expand **SQL Server Stores**. Right-click the SQL store of the new AlwaysOn Availability Group, and click ** Edit Properties**.
+    - Expand Skype for Business Server, expand your topology, and expand **SQL Server Stores**. Right-click the SQL store of the new AG, and click ** Edit Properties**.
     
-    - At the bottom of the page, in the **SQL Server FQDN** box, change the value to the FQDN of the Listener of the AlwaysOn Availability Group.
+    - At the bottom of the page, in the **SQL Server FQDN** box, change the value to the FQDN of the Listener of the AG.
     
     - Publish the topology. From the **Action** menu click **Topology** and then **Publish**. Then in the confirmation page click **Next**. Then wait a few minutes for the new topology to replicate.
     
-    - Open SQL Server Management Studio, and navigate to the AlwaysOn Availability Group. Fail it over to a secondary replica.
+    - Open SQL Server Management Studio, and navigate to the AG. Fail it over to a secondary replica.
     
     - Open Skype for Business Server Management Shell and type the following cmdlet to create the SQL logins on this replica:
     


### PR DESCRIPTION
AlwaysOn has had a space for 3 years. It hasn't been fixed in all UI elements, and I di didn't fix those. Most, if not all, SQL Server documentation has been changed to reflect this. Yours should as well, hence these changes. As per
https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/always-on-availability-groups-sql-server?view=sql-server-2017
"[NOTE] Always On availability groups is the full, formal name for this availability feature. The abbreviation is AG, not AOAG or AAG."

Also, Failover Clustering is the feature, a Windows Server Failover Cluster (WSFC) is the cluster itself.

I also deleted this
> [!IMPORTANT]
> Instance names for multiple Always On avialbility group instances must be the same. 

This is not true. INstance names can be different. The data paths should be the same, and saying multiple Always On AG instances makes no sense in the SQL Server world.

Is this in your UI? If so it needs to be fixed:
    
    - In the **Define New SQL Store** page, first select the **High Availability Settings** check box, and then make sure that SQL AlwaysOn Availability Groups appears in the drop-down box.