### PR TITLE
Revised failure message wording

### DIFF
--- a/Skype/SfbServer/deploy/deploy-clients/room-systems-v2-scripts.md
+++ b/Skype/SfbServer/deploy/deploy-clients/room-systems-v2-scripts.md
@@ -207,7 +207,7 @@ param(
 
     # Non-OEMs need to use normal Windows 10 Enterprise.
     if (!$IsOem -and $IsIoT) {
-        Write-Host "You appear to have specified a path to Windows 10 Enterprise IoT media. However, you need to use Windows 10 Enterprise media."
+        Write-Host "You appear to have specified a path to Windows 10 Enterprise IoT media, or a Multiple-Editions version that does not include Enterprise Edition. However, you need to use Windows 10 Enterprise media."
         return $false
     }
 


### PR DESCRIPTION
The vanilla "Multiple Editions" ISO of Windows does not include Enterprise Edition and (correctly) fails the version test. Amended the error message to add this as a possible reason for the failure.