### PR TITLE
Fixing Typo

### DIFF
--- a/Skype/SfbServer/deploy/integrate-with-exchange-server/high-resolution-photos.md
+++ b/Skype/SfbServer/deploy/integrate-with-exchange-server/high-resolution-photos.md
@@ -31,12 +31,12 @@ In Skype for Business Server 2015 photos can be stored in a user's Exchange Serv
 High-resolution photos, which are accessed by using Exchange Web Services, can be uploaded by users who are running Outlook 2013 Web App; users are only allowed to update their own photo. Administrators, however, can update the photo for any user by using the Exchange Management Shell and a series of Windows PowerShell commands similar to the following:
   
 ```
-$photo = ([Byte ] $(Get-Content -Path "C:\Photos\Kenmyer.jpg" -Encoding Byte -ReadCount 0))
+$photo = ([Byte[]] $(Get-Content -Path "C:\Photos\Kenmyer.jpg" -Encoding Byte -ReadCount 0))
 Set-UserPhoto -Identity "Ken Myer" -PictureData -Preview $photo -Confirm:$False
 Set-UserPhoto -Identity "Ken Myer" -Save -Confirm:$False
 ```
 
-The first command in the preceding example uses the Get-Content cmdlet to read the contents of the file C:\Photos\Kenmyer.jpg and store that data in a variable named Preview$photo. In the second command, the Exchange cmdlet Set-UserPhoto is used to upload the photo and attach that photo to Ken Myer's user account.
+The first command in the preceding example uses the Get-Content cmdlet to read the contents of the file C:\Photos\Kenmyer.jpg and store that data in a variable named $photo. In the second command, the Exchange cmdlet Set-UserPhoto is used to upload the photo and attach that photo to Ken Myer's user account.
   
 > [!NOTE]
 > In this example, Ken Myer's Active Directory display name is used as the user account Identity. You can also reference a user account by using other identifiers such as the user's SMTP address or his or her User Principal Name. See the documentation for the Set-UserPhoto cmdlet at [https://go.microsoft.com/fwlink/p/?LinkId=268536](https://go.microsoft.com/fwlink/p/?LinkId=268536) for more information

--- a/Skype/SfbServer/deploy/integrate-with-exchange-server/high-resolution-photos.md
+++ b/Skype/SfbServer/deploy/integrate-with-exchange-server/high-resolution-photos.md
@@ -36,7 +36,7 @@ Set-UserPhoto -Identity "Ken Myer" -PictureData -Preview $photo -Confirm:$False
 Set-UserPhoto -Identity "Ken Myer" -Save -Confirm:$False
 ```
 
-The first command in the preceding example uses the Get-Content cmdlet to read the contents of the file C:\Photos\Kenmyer.jpg and store that data in a variable named $photo. In the second command, the Exchange cmdlet Set-UserPhoto is used to upload the photo and attach that photo to Ken Myer's user account.
+The first command in the preceding example uses the `Get-Content` cmdlet to read the contents of the file C:\Photos\Kenmyer.jpg and store that data in a variable named $photo. In the second command, the Exchange cmdlet `Set-UserPhoto` is used to upload the photo and attach that photo to Ken Myer's user account.
   
 > [!NOTE]
 > In this example, Ken Myer's Active Directory display name is used as the user account Identity. You can also reference a user account by using other identifiers such as the user's SMTP address or his or her User Principal Name. See the documentation for the Set-UserPhoto cmdlet at [https://go.microsoft.com/fwlink/p/?LinkId=268536](https://go.microsoft.com/fwlink/p/?LinkId=268536) for more information
@@ -55,6 +55,4 @@ https://atl-mail-001.litwareinc.com/ews/Exchange.asmx/s/GetUserPhoto?email=kenmy
 
 If the administrator can view the photo using Internet Explorer but the user cannot view his or her photo in Skype for Business there may be a connectivity problem with Exchange Web Services or with the Exchange autodiscover service.
   
-Note, too that no additional configuration is required in order to make this photo available in Skype for Business. Instead, the photo will be instantly available after it has been uploaded and the Set-UserPhoto cmdlet has been run.
-  
-
+Note, too that no additional configuration is required in order to make this photo available in Skype for Business. Instead, the photo will be instantly available after it has been uploaded and the `Set-UserPhoto` cmdlet has been run.


### PR DESCRIPTION
Wrong syntax, it should be 
$photo = ([Byte[]] $(Get-Content -Path "C:\Photos\Kenmyer.jpg" -Encoding Byte -ReadCount 0))
Set-UserPhoto -Identity "Ken Myer" -PictureData -Preview $photo -Confirm:$False
Set-UserPhoto -Identity "Ken Myer" -Save -Confirm:$False

Also added some back-tick on cmdlets.
--


