### PR TITLE
Update .openpublishing.redirection.json

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -5,6 +5,11 @@
       "redirect_url": "https://docs.microsoft.com/en-us/SkypeForBusiness/what-are-calling-plans-in-office-365", 
       "redirect_document_id": true 
   
-    }  
+    },
+    {
+      "source_path": "Teams/teams-and-skypeforbusiness-interoperability.md", 
+      "redirect_url": "https://docs.microsoft.com/microsoftteams/teams-and-skypeforbusiness-coexistence-and-interoperability", 
+      "redirect_document_id": true 
+    }
   ] 
 }


### PR DESCRIPTION
Redirect the retired Teams interop documentation to the new Teams coexistence and interop documentation