### PR TITLE
Update provisioning-skype-room-system-accounts-in-office-365.md

### DIFF
--- a/Skype/SfbServer/deploy/deploy-clients/provisioning-skype-room-system-accounts-in-office-365.md
+++ b/Skype/SfbServer/deploy/deploy-clients/provisioning-skype-room-system-accounts-in-office-365.md
@@ -83,10 +83,16 @@ New-Mailbox -Name "Conf Room 2" -MicrosoftOnlineServicesID $rm -Room  -EnableRoo
 The previous commands set up or create a new Exchange resource mailbox account for Skype Room System usage by enabling the account.
   
 After creating the mailbox, you can use the Set-CalendarProcessing cmdlet in Exchange Online PowerShell to configure the mailbox. Refer to steps 3 through 6 under Single forest on-premises deployments for more details
+
+## Assigning a Skype for Business Online license
+
+Now you can assign a Skype for Business Online (Plan 2) or Skype for Business Online (Plan 3) license by using the Office 365 administrative portal as described in [Assign or remove licenses for Office 365 for business](https://support.office.com/en-us/article/Assign-or-remove-licenses-for-Office-365-for-business-997596b5-4173-4627-b915-36abac6786dc?ui=en-US&amp;rs=en-US&amp;ad=US) or in [Skype for Business add-on licensing](https://support.office.com/en-US/article/Skype-for-Business-add-on-licensing-3ed752b1-5983-43f9-bcfd-760619ab40a7). 
+  
+After you assign a license for Skype for Business Online, you will be able to log in and validate that the account is active using any Skype for Business client.
   
 ## Skype for Business Online provisioning
 
-After a resource room mailbox account has been created and enabled as shown previously, the account will synchronize from the Exchange Online forest to Skype for Business Online forest by using the Windows Azure Active Directory forest. The following steps are required to provision the Skype Room System account in the Skype for Business Online pool. These steps are the same for both an existing resource mailbox account or a newly created account (confrm1 or confrm2), because once they are enabled in Exchange Online, both of these accounts will be synchronized to Skype for Business Online in the same way:
+After a resource room mailbox account has been created and enabled as shown previously, and you have licensed the account for Skype For Business oline the account will synchronize from the Exchange Online forest to Skype for Business Online forest by using the Windows Azure Active Directory forest. The following steps are required to provision the Skype Room System account in the Skype for Business Online pool. These steps are the same for both an existing resource mailbox account or a newly created account (confrm1 or confrm2), because once they are enabled in Exchange Online, both of these accounts will be synchronized to Skype for Business Online in the same way:
   
 1. Create a Remote PowerShell session. Note that you will need to download Skype for Business Online Connector Module and Microsoft Online Services Sign-In Assistant and make sure that your computer is configured. For more information, see [Configuring Your Computer for Lync Online Management](http://technet.microsoft.com/library/bca143e2-659a-4161-9220-59ffd9fc2874.aspx).
     
@@ -108,11 +114,6 @@ After a resource room mailbox account has been created and enabled as shown prev
    Get-CsOnlineUser -Identity 'alice@contoso.onmicrosoft.com'| fl *registrarpool*
    ```
 
-## Assigning a Skype for Business Online license
-
-After you enable a Skype Room System account in Skype for Business, you can assign a Skype for Business Online (Plan 2) or Skype for Business Online (Plan 3) license by using the Office 365 administrative portal as described in [Assign or remove licenses for Office 365 for business](https://support.office.com/en-us/article/Assign-or-remove-licenses-for-Office-365-for-business-997596b5-4173-4627-b915-36abac6786dc?ui=en-US&amp;rs=en-US&amp;ad=US) or in [Skype for Business add-on licensing](https://support.office.com/en-US/article/Skype-for-Business-add-on-licensing-3ed752b1-5983-43f9-bcfd-760619ab40a7). 
-  
-After you assign a license for Skype for Business Online, you will be able to log in and validate that the account is active using any Skype for Business client.
   
 ## Password expiration
 


### PR DESCRIPTION
I think that the product behavior must have changed, because the system won't allow us to run enable-csmeetingroom on an account that is not licensed for Skype for Business Online. We have had multiple support cases on this. The most recent one is: 7976962. 
Also the workflow presented on the diagram should be changed: The step "Enable account in SfB Pool" should be after "Assign SfB online license via control panel".