### PR TITLE
Update needed. INcorrect info

### DIFF
--- a/Teams/guest-access-checklist.md
+++ b/Teams/guest-access-checklist.md
@@ -63,7 +63,7 @@ In the Office 365 admin center, go to **Settings** > **Services & Add-ins** > **
 
 Make sure **Let group members outside the organization access group content** is set to **On**. If this setting is turned off, guests won't be able to access any group content.
 
-Make sure **Let group owners add people outside the organization to groups** is set to **On**. If this setting is turned off, Team owners won't be able to add new guests. (However, if an admin had added a guest user to Azure AD, then the Team owner would be able to add that user to the Team.) At a minimum,  this setting must be "on" to support guest access.
+Make sure **Let group owners add people outside the organization to groups** is set to **On**. If this setting is turned off, Team owners won't be able to add new guests. At a minimum,  this setting must be "on" to support guest access.
 
 For detailed instructions about configuring these settings, see the section "Office 365 Groups" in [Authorize guest access in Microsoft Teams](Teams-dependencies.md) and [Allow/Block guest access to Office 365 groups](https://go.microsoft.com/fwlink/?linkid=869658).
  


### PR DESCRIPTION
This statement in the article is not true
(However, if an admin had added a guest user to Azure AD, then the Team owner would be able to add that user to the Team.)