### PR TITLE
Update configure-direct-routing.md

### DIFF
--- a/Skype/SfbServer/skype-for-business-hybrid-solutions/plan-your-phone-system-cloud-pbx-solution/configure-direct-routing.md
+++ b/Skype/SfbServer/skype-for-business-hybrid-solutions/plan-your-phone-system-cloud-pbx-solution/configure-direct-routing.md
@@ -341,7 +341,7 @@ In some cases there is a need to route all calls to the same SBC; please use -Nu
 - Route all calls to same SBC
 
     ```
-    Set-CsOnlineVoiceRoute -id "Redmond 1" -NumberPattern "." 
+    Set-CsOnlineVoiceRoute -id "Redmond 1" -NumberPattern ".*" 
      -OnlinePstnGatewayList sbc1.contoso.biz
     ```
 


### PR DESCRIPTION
Fix PS Cmdlet example for Route all calls to same SBC with correct syntax of ".*"
Was "." which is wrong and will fail to route calls correctly.