### PR TITLE
Configure online hybrid med server - Change

### DIFF
--- a/Skype/SfbServer/skype-for-business-hybrid-solutions/plan-your-phone-system-cloud-pbx-solution/configure-cloud-connector-integration-with-your-office-365-tenant.md
+++ b/Skype/SfbServer/skype-for-business-hybrid-solutions/plan-your-phone-system-cloud-pbx-solution/configure-cloud-connector-integration-with-your-office-365-tenant.md
@@ -161,7 +161,7 @@ When a P2P call is escalated to a PSTN conference, the Skype for Business Online
     
     Use the default SIP domain of Cloud Connector (the first SIP domain in the .ini file) as the user domain.
     
-    Assign an Office 365 licenses (such as E5) to the account you create.
+    Please note that license assignment is only required for the user propagation into the Skype for Business online directory. Assign an Office 365 licenses (such as E5) to the account you create, allow up to one hour for the changes to propagate, then remove the license from this account.
     
 2. Start a tenant remote PowerShell session using your tenant admin credentials, and then run the following cmdlet to set the Mediation Server and Edge Server FQDN to that user account, replacing \<DisplayName\> with the Display Name of the user for the account you created:
     


### PR DESCRIPTION
Please note that it is not possible to run the Set-CsHybridMediationServer cmdlet against a licensed account. Following error will be thrown:
"User with identity "user" has licenses assigned. It cannot be set as Hybrid Mediation Server. Please remove all the licenses for it or re-create a new user without any license and try again."

However, license is still required to be added on this account for it to be replicated into the SfB online directory. 
Correct action would be:
1. Create user and assign license. 
2. Wait up to one hour for the account to be replicated into the SfB online directory.
3. Remove the license.
4. Might take 5-10 minutes after license removal. (time it takes for the customer to connect to remote ps, should be enough).
5. Run the set-csHybridMediationServer cmdlet.


Please let me know if there are any questions.
Thanks,
Sabin