### PR TITLE
Add check for TeamsPath before deleting

### DIFF
--- a/Teams/scripts/Powershell-script-teams-deployment-clean-up.md
+++ b/Teams/scripts/Powershell-script-teams-deployment-clean-up.md
@@ -38,9 +38,10 @@ try
         # Uninstall app
         $proc = Start-Process -FilePath $TeamsUpdateExePath -ArgumentList "-uninstall -s" -PassThru
         $proc.WaitForExit()
-    }{
-    Write-Host "Deleting Teams directory"
-    Remove-Item –Path $TeamsPath -Recurse
+    }
+    if (Test-Path -Path $TeamsPath) {
+        Write-Host "Deleting Teams directory"
+        Remove-Item –Path $TeamsPath -Recurse
     }
 }
 catch


### PR DESCRIPTION
With the code in the {} block below, the Teams folder does not delete for me.  If I remove the start { and end }, the folder does delete.  I would think that things would function the same with or without those braces.  It seems like the braces should not be needed, but they also should not hurt.  In my environment, the folder is not deleted if those braces are there though.  I'm wondering if there is some sort of parsing difference going on in different versions of PowerShell that have been giving people different results.
{
    Write-Host "Deleting Teams directory"
    Remove-Item –Path $TeamsPath -Recurse
    }

However, I think it is better anyway to not try and delete the TeamsPath folder without checking that it exists first.  So, instead of just removing the braces in my environment, I added a check for TeamsPath existing and kept the braces.  

if (Test-Path -Path $TeamsPath) {
        Write-Host "Deleting Teams directory"
        Remove-Item –Path $TeamsPath -Recurse
}