### PR TITLE
Update SRSv2 installation documentation

### DIFF
--- a/Skype/SfbServer/deploy/deploy-clients/console.md
+++ b/Skype/SfbServer/deploy/deploy-clients/console.md
@@ -44,10 +44,9 @@ Installing the Skype Room Systems v2 app on a Surface Pro 4 or Surface Pro requi
 > [!NOTE]
 > An existing Skype Room Systems v2 with Windows 10 Enterprise Anniversary Update moving to Skype Room Systems v2 update 3 by way of the Windows Store will work, but a new installation should be done as described below. 
   
-1. Download the [MSU for KB4056892](http://download.windowsupdate.com/c/msdownload/update/software/secu/2018/01/windows10.0-kb4056892-x64_a41a378cf9ae609152b505c40e691ca1228e28ea.msu).
-2. Download the [CreateSrsMedia.ps1 script](https://go.microsoft.com/fwlink/?linkid=867842).
-3. Place the MSU for KB4056892 in the same directory as the CreateSrsMedia.ps1 script.
-4. Run the CreateSrsMedia.ps1 script from an elevated prompt on a Windows 10 machine.
+1. Download the [CreateSrsMedia.ps1 script](https://go.microsoft.com/fwlink/?linkid=867842).
+2. (Optional) Download and place any desired language pack CAB files in the same directory as the script. The script will indicate where you can download language pack files appropriate for the type of media you are creating, if you're unsure where to acquire the language packs from.
+3. Run the CreateSrsMedia.ps1 script from an elevated prompt on a Windows 10 machine.
 
 
 Follow the script's instructions to create a Skype Room Systems v2 USB setup disk. When finished, remove the USB disk from your computer and proceed to [Install Windows 10 and the Skype Room Systems v2 console app ](console.md#Reimage).


### PR DESCRIPTION
The installation script now automatically handles downloading any
Windows updates that may be required. The manual steps for this are
obsolete, and have been removed.

Language packs must still be manually downloaded and placed. The script
does not, however, indicate where downloaded LPs should be placed.
Updated the documentation to clarify this, pending the built-in
documentation being fixed.