### PR TITLE
Replace "accepted domain" to "allowed domain"

### DIFF
--- a/Teams/SMTP-accepted-domain.md
+++ b/Teams/SMTP-accepted-domain.md
@@ -1,5 +1,5 @@
 ---
-title: Add the Microsoft Teams SMTP domain as an accepted domain in Exchange Online
+title: Add the Microsoft Teams SMTP domain as an allowed sender domain in Exchange Online
 author: LolaJacobsen
 ms.author: lolaj
 manager: serdars
@@ -7,12 +7,12 @@ ms.date: 09/25/2017
 ms.topic: article
 ms.service: msteams
 ms.reviewer: anprakas
-description: Learn to add the Microsoft Teams SMTP domain as an accepted domain in Exchange Online to send notifications to team members.
+description: Learn to add the Microsoft Teams SMTP domain as an allowed sender domain in Exchange Online to send notifications to team members.
 appliesto: 
 - Microsoft Teams
 ---
 
-Add the Microsoft Teams SMTP domain as an accepted domain in Exchange Online 
+Add the Microsoft Teams SMTP domain as an allowed sender domain in Exchange Online 
 =============================================================================
 
 Whether you create an Office 365 Group in the admin console or by using Outlook, Exchange Online is used to send notifications of a team member being added to a Group. These messages are generated from your tenant as they represent your default domain SMTP FQDN.
@@ -23,6 +23,6 @@ Teams uses Microsoft Exchange Online as well to send notifications to team membe
 
 ![Screenshot of an example Outlook email message header showing a user has been added to a group.](media/Add_the_Microsoft_Teams_SMTP_domain_as_an_accepted_domain_in_Exchange_Online_image2.jpg)
 
-For best result and seamless operation, consider adding the Microsoft Teams SMTP domain to your “accepted domains” list in your Exchange Online spam configuration:
+For best result and seamless operation, consider adding the Microsoft Teams SMTP domain to your “allowed sender domains” list in your Exchange Online spam configuration:
 
 ![Screenshot of the Allow lists section of Exchange Online spam configuration settings.](media/Add_the_Microsoft_Teams_SMTP_domain_as_an_accepted_domain_in_Exchange_Online_image3.png)


### PR DESCRIPTION
@kenwith   Based on Issue #483, I propose to replace to "accepted domain" to "allowed sender domain."