### PR TITLE
Update country-and-region-availability-for-audio-conferencing-and-cal…

### DIFF
--- a/Skype/SfbOnline/country-and-region-availability-for-audio-conferencing-and-calling-plans/country-and-region-availability-for-audio-conferencing-and-calling-plans.md
+++ b/Skype/SfbOnline/country-and-region-availability-for-audio-conferencing-and-calling-plans/country-and-region-availability-for-audio-conferencing-and-calling-plans.md
@@ -153,9 +153,6 @@ In Audio Conferencing there is a feature named "*Call Me*" and it can be used to
   
 Dialing out from a meeting to another country/region in the world that is not listed below is available using [Office 365 Communication Credits](../skype-for-business-and-microsoft-teams-add-on-licensing/what-are-communications-credits.md). For those users, you will need to [set up Communications Credits for your organization](../skype-for-business-and-microsoft-teams-add-on-licensing/set-up-communications-credits-for-your-organization.md).
   
-> [!NOTE]
-> During the introductory period, users in all organizations can dial out to when using the Call Me feature or when adding other people to a meeting to any of the following countries/regions at no additional charge, but this is subject to the [Audio Conferencing complimentary dial-out period](../legal-and-regulatory/complimentary-dial-out-period.md). 
-  
 ### Phone System
 With Phone System, you can create auto attendants and call queues (with a toll or toll-free number) to answer incoming calls for your organization, and when you add a Calling Plan for users they can use Skype for Business to take care of basic call-control tasks, such as placing and receiving calls, transferring calls, and muting and unmuting calls. **Phone System** users can click a name in their address book and Skype for Business will place a call to that person. To place and receive calls, **Phone System** users can use their mobile devices, a headset with a laptop or PC, or one of many IP phones that work with Skype for Business.
 


### PR DESCRIPTION
…ling-plans.md

This document should be updated now that the introductory period for dial out to 44 countries has expired as of 6/30/2018. 
https://docs.microsoft.com/en-us/skypeforbusiness/legal-and-regulatory/complimentary-dial-out-period. 

Suggest removing note about complimentary period. 
Also paragraph starting on Line 154 refers to list below, but there is no list below and I believe this related to complimentary countries which is no longer available. We need clarification on when dial out requires communication credits. Is this whenever calling outside of country/region user is assigned to in O365?


"Dialing out from a meeting to another country/region in the world that is not listed below is available using [Office 365 Communication Credits](../skype-for-business-and-microsoft-teams-add-on-licensing/what-are-communications-credits.md). For those users, you will need to [set up Communications Credits for your organization](../skype-for-business-and-microsoft-teams-add-on-licensing/set-up-communications-credits-for-your-organization.md)."