### PR TITLE
update for Public team list not displaying

### DIFF
--- a/Teams/Known-issues.md
+++ b/Teams/Known-issues.md
@@ -210,7 +210,7 @@ This article lists the known issues for Microsoft Teams, by feature area.
 
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|
-|Public team list does not display all teams  <br/> |The list of public teams is based on the Microsoft Graph.  <br/> |If you don't see a team, try searching for it in the top right search box and team owners communicate team names to colleagues <br/> | 7/21/17  <br/>|
+|Public team list does not display all teams  <br/> |The list of public teams is based on the Microsoft Graph.  <br/> |If you don't see a team, try searching for it in the top right search box. Also, the team owners should communicate team names to colleagues since many teams could show up in the search results. <br/> | 7/21/17  <br/>|
 
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|

--- a/Teams/Known-issues.md
+++ b/Teams/Known-issues.md
@@ -210,7 +210,7 @@ This article lists the known issues for Microsoft Teams, by feature area.
 
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|
-|Public team list does not display all teams  <br/> |The list of public teams is based on the Microsoft Graph.  <br/> |If you don't see a team, try searching for it in the top right search box.  <br/> | 7/21/17  <br/>|
+|Public team list does not display all teams  <br/> |The list of public teams is based on the Microsoft Graph.  <br/> |If you don't see a team, try searching for it in the top right search box and team owners communicate team names to colleagues <br/> | 7/21/17  <br/>|
 
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|


### PR DESCRIPTION
Workaround is ineffective if you don't know what team you should be searching for, this needs to be communicate by the team owner through some other medium. Not practical for searchers to go through each letter of the alphabet hoping to find a match, for example.