### PR TITLE
Update pilot-essentials.md

### DIFF
--- a/Teams/pilot-essentials.md
+++ b/Teams/pilot-essentials.md
@@ -98,7 +98,7 @@ If your results indicate:
 -   **Your pilot goals (for example, user satisfaction and network quality) have been achieved**, you should be ready to proceed with the next phase of your rollout. Depending on the goals of your project, this could be one of the following:
    -   Extending the pilot to additional participants
    -   [Enabling Teams alongside Skype for Business (**Islands** mode) for some or all of your organization](https://aka.ms/SkypeToTeams-SetCoexistence)
-   -   [Upgrading users from Skype for Business to Teams (**Teams only** mode) for some or all of your organization](https://aka.ms/SkypeToTeams-SetCoexistence)
+   -   [Upgrading users from Skype for Business to Teams (**Teams only** mode) for some or all of your organization](https://aka.ms/SkypeToTeams-SetCoexistence) [Add a note here to explain that once some users are upgraded to Teams all other users need to be assigned an SfBMode. We should also include information and recommendation for other SfB Modes.]
 -   **Your pilot didn’t achieve the outcomes you wanted (for example, user satisfaction and network quality)**, take time to make the appropriate adjustments to your plan and revisit your pilot.
 
 > [!Tip]


### PR DESCRIPTION
In light of new Upgrade Modes, we need to expand on guidance around upgrading users to Teams. Islands Mode only works as long as all users using both SfB and Teams side by side. Once any user is upgraded to Teams there is a danger that messages to SfB users who have never used Teams will fail to send and there will be no indication otherwise because these users will look like Teams users since drawbridge has been removed. We should also provide guidance to IT Pro's that they can view user activity/last log in times for Teams in the Modern Portal. 

Legacy behavior. Teams user initiates chat to SfB user who has never signed into Teams. Teams shows this user as an SfB user with option to Invite them to Teams. 

New behavior. Teams user initiates chat to SfB user who has never signed into Teams and has Islands Mode assigned. Teams shows this chat as a regular Teams chat and messages will route to Teams chat service. The end user will not be aware that the recipient has never signed into Teams and won't receive the Chat. 

Please reach out to cbland@microsoft and kkodali@microsoft.com for more information if needed.