### PR TITLE
Update let-your-teams-users-communicate-with-other-people.md

### DIFF
--- a/Teams/let-your-teams-users-communicate-with-other-people.md
+++ b/Teams/let-your-teams-users-communicate-with-other-people.md
@@ -40,11 +40,13 @@ Follow these steps:
 
    2. At the top of the **External access** page, click **External access** to **On**. 
 
-   3. Add the other organization's domain to the allowed list by clicking **Add domain**. In the **Add a domain** pane, put in the domain name click **Allowed** and then **Done**.
+   3. If you want to allow all Teams organizations to communicate with users in your organization, skip to step 5. 
+   
+   4. If you want to limit which organizations can communicate with users in your organization, add the other organization's domain to the allowed list by clicking **Add domain**. In the **Add a domain** pane, put in the domain name click **Allowed** and then **Done**.
 
    4. Click **Save**. 
 
-   5. Then make sure the admin in the other Teams  organization does these same steps. For example, in their **allowed domains** list, their admin needs to enter the domain for your business.
+   5. Then make sure the admin in the other Teams  organization does these same steps. For example, in their **allowed domains** list, their admin needs to enter the domain for your business if they limit which organizations can communicate with their users. 
 
 ### Step 3 - Test it
 To test your setup, you need a Teams user who's not behind your firewall.
@@ -59,7 +61,7 @@ To test your setup, you need a Teams user who's not behind your firewall.
 
 ## Communicate with users in a Skype for Business Online organization
 
-If you are setting it up to let your Teams users find and contact users that are in a Skype for Business organization, you will the admin in that organization to follow these steps.
+If you are setting it up to let your Teams users find and contact users that are in a Skype for Business organization that limits who can contact their users, you will ask the admin in that organization to follow these steps.
 
 ![sfb-logo-30x30.png](media/sfb-logo-30x30.png) **Using Skype for Business admin center** 
 
@@ -71,7 +73,7 @@ Have the admin in that organization do these steps:
     
 3. To set up communication with a specific business or with users in another domain, in the drop-down box, choose **On only for allowed domains**.
     
-    OR, if you want to enable communication with everyone else in the world who has open Skype for Business policies, choose **On except for blocked domains**. This is the default setting.
+    OR, if they want to enable communication with everyone else in the world who has open Skype for Business policies, choose **On except for blocked domains**. This is the default setting.
     
 4. Under **Blocked or allowed domains**, choose **+** and add the name of the domain you want to allow. Make sure the admin in the other organization does these same steps. For example, in their **allowed domains** list, their admin needs to enter the domain for your business.
     


### PR DESCRIPTION
I tried to update this but I'm not sure of the intent of the Skype for Business Online Organization section. Couple of things:
1. Teams and Skype are now managed under one section in the Modern Portal - should be available to all customers shortly if not there now.
2. The configuration for Teams and Skype federation online is identical - there is no difference
3. The default is allow all domains. Once any domain is added to the list its no longer open federation. That said the modern portal has a bug right now that is showing Microsoft managed domains. 
https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdomoreexp.visualstudio.com%2Fad4dc0b3-25d1-44f6-a766-8670592cc9a9%2F_workitems%2Fedit%2F360017%3Ftracking_data%3DeyJTb3VyY2UiOiJFbWFpbCIsIlR5cGUiOiJOb3RpZmljYXRpb24iLCJTSUQiOiIxOTU3ODAiLCJTVHlwZSI6IlBFUiIsIlJlY2lwIjoxLCJFbGVtZW50Ijoic3VtbWFyeV9pZF9saW5rIn0%253d&data=02%7C01%7C%7Cf8703c83fa5440e984c108d60dc6d944%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636711545032522533&sdata=pbirTWnDyeISrcsoRO8TX1j945w4IVDNXvNNPVsvBtw%3D&reserved=0

This document should be changed to just one section managing Teams/Skype federation with Enabled set for default to allow all organizations and if administrator wants to restrict then they should add specific domains. If other organizations they want to communicate with also restrict domains, they should ask that administrator to add their domain to their tenant allow list.