### PR TITLE
remove links to "phones and devices home" and "compatible devices pro…

### DIFF
--- a/Skype/SfbPartnerCertification/certification/test-spec.md
+++ b/Skype/SfbPartnerCertification/certification/test-spec.md
@@ -79,10 +79,4 @@ Use the following table to find the tools for testing USB peripherals, PCs, and 
 
 ### Related resources
 
-[Phones and devices home](devices-ip-phones.md)
-
-[Compatible Devices Program](../lync-cert/partner-qualification.md#compatible-devices-program)
-
-If you are a vendor seeking to join the certification program, see [How to Join](how-to-join.md) for requirements and available programs.
-
 View the [partner solutions catalog](http://partnersolutions.skypeforbusiness.com/solutionscatalog/) to see products certified for Skype for Business.


### PR DESCRIPTION
…gram"

these links are redundant given the current tree structure of the site, and one of them was an incorrect link since it pointed to the Lync variant of the page instead of the SfB variant.