### PR TITLE
Update limits-specifications-teams.md

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -27,7 +27,7 @@ Teams and channels
 |-----------|---------------|
 |Number of teams a user can create | 250         |
 |Number of members in a team | 2,500       |
-|Number of teams a global admin can create        | Unlimited   |
+|Number of teams a global admin can create        | 500,000   |
 |Number of teams an Office 365 tenant can have    | 500,000     |
 |Number of channels per team    | 200         |
 


### PR DESCRIPTION
Updated "Number of teams a global admin can create" from Unlimited to 500,000 as that is the absolute cap on the number of Teams in a tenant.