### PR TITLE
Made edits to clarify role and entry-points

### DIFF
--- a/Teams/tenant-apps-catalog-teams.md
+++ b/Teams/tenant-apps-catalog-teams.md
@@ -22,9 +22,11 @@ You can use the Microsoft Teams Tenant Apps Catalog to test and distribute line-
 
 The Teams Tenant Apps Catalog lets you distribute your line-of-business applications that were built specifically for your organization and that you rely on to complete critical business functions to your users. 
  
-You can publish apps to the Teams Tenant Apps Catalog directly from the Teams client.
+Sign in to your Teams client using your global admin credentials and publish apps for your organization. 
 
 ## Publish an app to the Tenant Apps Catalog from the Teams client
+
+NOTE: You need to be signed in to the Microsoft Teams client using your global admin credentials to publish apps for your organization.
 
 ### Get a Teams app package
 
@@ -32,7 +34,7 @@ A Teams app package is created by using [Teams App Studio](https://docs.microsof
 
 ### Go to the Tenant Apps Catalog
 
-From the Microsoft Teams Store, select the new section named for your specific organization (in this example, Contoso). Users in your organization can view apps in the catalog and install them to teams of which they are a member. 
+Launch the Microsoft Teams client and sign-in using your global admin credentials. From the Microsoft Teams Store, select the new section named for your specific organization (in this example, Contoso). Users in your organization can view apps in the catalog and install them to teams of which they are a member. 
 
 ![Screenshot of the Teams App Store showing the app catalog.](media/private-app-store-teams-image01.png)
 


### PR DESCRIPTION
Added clarification that the user needs to be in the Teams client and signed in using their global admin credentials in order to publish/update/remove apps to their organization.
Enterprises are getting confused about these specifics.