### PR TITLE
Corrected Set-UserPhoto Example

### DIFF
--- a/Skype/SfbServer/deploy/integrate-with-exchange-server/high-resolution-photos.md
+++ b/Skype/SfbServer/deploy/integrate-with-exchange-server/high-resolution-photos.md
@@ -32,7 +32,7 @@ High-resolution photos, which are accessed by using Exchange Web Services, can b
   
 ```
 $photo = ([Byte[]] $(Get-Content -Path "C:\Photos\Kenmyer.jpg" -Encoding Byte -ReadCount 0))
-Set-UserPhoto -Identity "Ken Myer" -PictureData -Preview $photo -Confirm:$False
+Set-UserPhoto -Identity "Ken Myer" -PictureData $photo -Preview -Confirm:$False
 Set-UserPhoto -Identity "Ken Myer" -Save -Confirm:$False
 ```
 


### PR DESCRIPTION
`-Preview` was between `-PictureData` and the photo variable making the command invalid.