### PR TITLE
Update validated-lync-apps.md

### DIFF
--- a/Skype/SfbPartnerCertification/lync-cert/validated-lync-apps.md
+++ b/Skype/SfbPartnerCertification/lync-cert/validated-lync-apps.md
@@ -13,8 +13,7 @@ ms.service: skype-for-business
 ms.collection: Lync
 ms.audience: Admin
 appliesto:
-- Lync
-- Skype for Business 
+- Lync 2013
 localization_priority: Normal
 f1keywords: None
 ms.custom:


### PR DESCRIPTION
the applications are certified for Lync and not skype for business server. The "applied to" field creates confusion for customers, insisting that the documentation clearly shows that this particular list of certified application is also certified for skype for business. 