### PR TITLE
Correcting the command for disable auto launch

### DIFF
--- a/Teams/msi-deployment.md
+++ b/Teams/msi-deployment.md
@@ -61,5 +61,5 @@ If a user uninstalls Teams from their User Profile, the MSI installer will track
 
 If you want to disable auto launch, enter the following command prompt:
 
-`msiexec /i Teams_windows.exe OPTIONS="noAutoStart=true"`
+`msiexec /i Teams_windows.msi OPTIONS="noAutoStart=true"`
 


### PR DESCRIPTION
The command for installing using MSI is incorrect. It should be MSI instead of the exe.