### PR TITLE
Need to clarify the NOTE about "CAP account's password will be chang…

### DIFF
--- a/Skype/SfbOnline/what-is-phone-system-in-office-365/getting-phones-for-skype-for-business-online/setting-up-common-area-phones.md
+++ b/Skype/SfbOnline/what-is-phone-system-in-office-365/getting-phones-for-skype-for-business-online/setting-up-common-area-phones.md
@@ -132,7 +132,7 @@ The phone or phones you have must have the **Common Area Phone mode** turned on.
 
 
 > [!NOTE]
-> The CAP provisioning site states it will reset the CAP account's password to a random password. Take note that the account the CAP is referring is the Azure Active Directory (AAD) account. If you created the account in AAD only then the process is straightforward. If you have synced an on premises Active Directory to AAD make sure to take note of the credentials you are using that will be changed by CAP provisioning.
+> The CAP provisioning site states it will reset the CAP account's password to a random password. Take note that the account the CAP is referring is the Azure Active Directory (AAD) account. If you created the account in AAD only then the process is straightforward. If you have synced an on premises Active Directory to AAD and you use a third-party IDP or ADFS, CAP provisioning will fail. In this case, you need to use an Office 365/Azure Active Directory account only (for example, an account with **onmicrosoft.com** domain) for CAP provisioning to work.
 
 
 ### Related topics


### PR DESCRIPTION
…ed to a random password."

I suggested a change, but the (original) text is not clear enough to me in this point " If you have synced an on premises Active Directory to AAD make sure to take note of the credentials you are using that will be changed by CAP provisioning."  Simply because during the provision process, there's no option to provide a password to CAP Service to use. Not sure if CAP should give a password so the SFBO admin can update that onprem. AAD Sync service offers the opportunity to Sync password between Onprem and Online and vice-versa automatically, but not all AAD Sync versions will permit that (older ones will not). It's really confusing. Also, there is a known problem, where if customer is using a third party idp or ADFS for authentication, CAP provision will fail. That's the change I made to the note, but we need to check on the other possible limitations I commented an updated the note to an even better version.