### PR TITLE
Update direct-routing-sbc-multiple-tenants.md

### DIFF
--- a/Teams/direct-routing-sbc-multiple-tenants.md
+++ b/Teams/direct-routing-sbc-multiple-tenants.md
@@ -122,7 +122,7 @@ For more information about admin roles and how to assign a role in Office 365, s
 
 ### Activate the domain name
 
-After you have registered a domain name, you need to activate it by adding at least one user and assign a SIP address with the FQDN portion of the SIP address matching the created base domain.
+After you have registered a domain name, you need to activate it by adding at least one E1, E3, or E5 licensed user and assigning a SIP address with the FQDN portion of the SIP address matching the created base domain. 
 
 *Please review [Get help with Office 365 domains](https://support.office.com/article/Get-help-with-Office-365-domains-28343f3a-dcee-41b6-9b97-5b0f4999b7ef) for more information about adding users in Office 365 tenants.*
 


### PR DESCRIPTION
To activate a user in a with sip address matching sip domain of SBC base FQDN requires the user is licensed for SfB Plan2 today, and Teams in the future when we change licensing sku's. To avoid that detail just added requirement for E1, E3, or E5 license. Not 100% sure if these are the only licenses today that include SfB Plan2 and in future will auto provision SfB shadow accounts with Teams license.