### PR TITLE
Updated license requirements

### DIFF
--- a/Teams/cloud-recording.md
+++ b/Teams/cloud-recording.md
@@ -26,7 +26,7 @@ Related: [Teams meeting recording end user documentation](https://aka.ms/recordm
 
 For a Teams user’s meetings to be recorded, Microsoft Stream must be enabled for the tenant. In addition, the following prerequisites are required for both the meeting organizer and the person who is initiating the recording:
 
-- User has an Office 365 Enterprise E1, E3, or E5 license
+- User has an Office 365 E1, E3, E5, A1, A3, A5, M365 Business, Business Premium or Business Essentials
 - User needs to be licensed for Microsoft Stream
 - User has Microsoft Stream upload video permissions
 - User has consented to the company guidelines, if set up by the admin


### PR DESCRIPTION
Per https://docs.microsoft.com/en-us/stream/license-overview all the following licenses allow uploading to Stream which is the required to do recording in Teams: E1, E3, E5, A1, A3, A5, M365 Business, Business Premium or Business Essentials