### PR TITLE
Update SharePoint-OneDrive-interact.md

### DIFF
--- a/Teams/SharePoint-OneDrive-interact.md
+++ b/Teams/SharePoint-OneDrive-interact.md
@@ -42,10 +42,10 @@ For every team, a SharePoint site is created, and the **Shared Documents** folde
 > It's not currently possible to replace the default SharePoint site and document library with another one. We've heard from you that you want it, and we're considering it. Check the [Teams Roadmap](https://aka.ms/teamsroadmap) or [Teams UserVoice](https://aka.ms/TeamsUserVoice) to stay on top of upcoming features.
 
 > [!TIP]
-> To add a tab to your team that links to an existing SharePoint site or to your existing SharePoint document library:
+> To add a tab to your team that links to an existing SharePoint site page or to your existing SharePoint document library:
 > 1. Select the  plus sign next to the tabs.
-> 2. Select **Website**.
-> 3. Type a name and enter the URL of your SharePoint site or document library.
+> 2. Select either **SharePoint** for an existing SharePoint site page or **Document Library** for an existing document library.
+> 3. Select the appropriate page or document library.
 
 For every user, the OneDrive folder **Microsoft Teams Chat Files** is used to store all files shared within private chats with other users (1:1 or 1:many), with permissions configured automatically to restrict access to the intended user only.
 


### PR DESCRIPTION
Website-type tab uses iframes for the web client. SharePoint Online will block this by default and the page will not load. The desktop client may load as it uses webviews. Authentication using the website-type tab is also separate from client authentication, requiring a user to re-auth. In addition, some features will not work in a website-type tab (ex. pop-ups) because of the framed session.

Changed reference from Website-type tab to SharePoint and Document Library tabs.