### PR TITLE
Update send-an-email-to-a-user-with-their-dial-in-information-in-team…

### DIFF
--- a/Teams/send-an-email-to-a-user-with-their-dial-in-information-in-teams.md
+++ b/Teams/send-an-email-to-a-user-with-their-dial-in-information-in-teams.md
@@ -64,8 +64,6 @@ Here is an example of the email that is sent:
   - When the audio conferencing provider for a user is changed from Microsoft to another provider or **None**.
     
   - When the audio conferencing provider for a user is changed to Microsoft.
-    
-- By default, the sender of the emails will be from Office 365, but you can change the email address and display name by using Windows PowerShell. See the [Microsoft Teams PowerShell reference](https://docs.microsoft.com/powershell/module/teams/?view=teams-ps) for more information.
   
 ## Want to know more about Windows PowerShell?
 


### PR DESCRIPTION
Removing a reference to the ability of changing the sender info of the emails that are sent by the service as the capability has been deprecated