### PR TITLE
Sample Script to Automate Firewall Rule Creation

### DIFF
--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -142,3 +142,22 @@ Notification settings
 There are currently no options available for IT administrators to configure client-side notification settings. All notification options are set by the user. The figure below outlines the default client settings.
 
 ![Screenshot of Notifications settings.](media/Get_clients_for_Microsoft_Teams_image6.png)
+
+Sample PowerShell Script
+----------------------------
+To automate creation of firewall rule to avoid Windows Firewall prompt when users initiate their first call in Microsoft Teams, administrators can run the following script on client computers in the context of an administrator. 
+
+$users = Get-Childitem c:\users
+foreach ($user in $users) 
+{
+    $Path = "c:\users\" + $user.Name + "\appdata\local\Microsoft\Teams\Current\Teams.exe"
+    if (Test-Path $Path) 
+	{
+	        $name = "teams.exe " + $user.Name
+	        if (!(Get-NetFirewallRule -DisplayName $name))
+		{
+	            New-NetFirewallRule -DisplayName “teams.exe” -Direction Inbound -Profile Domain -Program $Path -Action Allow
+		}
+	}
+}
+

--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -145,8 +145,10 @@ There are currently no options available for IT administrators to configure clie
 
 Sample PowerShell Script
 ----------------------------
-To automate creation of firewall rule to avoid Windows Firewall prompt when users initiate their first call in Microsoft Teams, administrators can run the following script on client computers in the context of an administrator. 
 
+This sample script, which needs to run on client computers in the context of an elevated administrator account, will create a new inbound firewall rule for each user folder found in c:\users. When Teams finds this rule, it will prevent the Teams application from prompting users to create firewall rules when the users make their first call from Teams. 
+
+```
 $users = Get-Childitem c:\users
 foreach ($user in $users) 
 {
@@ -160,4 +162,16 @@ foreach ($user in $users)
 		}
 	}
 }
+<#
+        .ABOUT THIS SCRIPT
+        (c) Microsoft Corporation 2018. All rights reserved. Script provided as-is without any warranty of any kind. Use it freely at your own risks.
 
+        Must be run with elevated permissions. Can be run as a GPO Computer Startup script, or as a Scheduled Task with elevated permissions. 
+
+        The script will create a new inbound firewall rule for each user folder found in c:\users. 
+
+        Requires PowerShell 3.0
+        
+#>
+
+```


### PR DESCRIPTION
We've been getting valid feedback from administrators that they do not want to ask end users to cancel security dialog for Firewall rule with explanation that it will work OK. This is both confusing to end users as well as bad practice to instruct users to ignore security dialogs. Administrators are asking us to please provide a mechanism to allow them to create appropriate firewall rules that will avoid the dialog. 

We have received the following sample script from engineering that works great and avoids the prompt. This script can be run as a GPO computer startup script. Can we add this sample script to this documentation so that administrators know how to control this end user experience.

Sample Script

$users = Get-Childitem c:\users
foreach ($user in $users) 
{
    $Path = "c:\users\" + $user.Name + "\appdata\local\Microsoft\Teams\Current\Teams.exe"
    if (Test-Path $Path) 
	{
	        $name = "teams.exe " + $user.Name
	        if (!(Get-NetFirewallRule -DisplayName $name))
		{
	            New-NetFirewallRule -DisplayName “teams.exe” -Direction Inbound -Profile Domain -Program $Path -Action Allow
		}
	}
}