### PR TITLE
Update Known-issues.md

### DIFF
--- a/Teams/Known-issues.md
+++ b/Teams/Known-issues.md
@@ -158,7 +158,7 @@ This article lists the known issues for Microsoft Teams, by feature area.
 
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|
-|Users can't access Meetings/Connectors but have Exchange Online mailboxes. <br/> |Customer actively blocks EWS from services within Exchange Online but needs to have MS Teams compliant within EWS policies. <br/> |To make MS Teams compliant, you must add the following User Agent String for MS Teams within the EWSAllowList: `*skypespaces*`, including asterisks. The full command is: `set-organizationconfig -ewsallowlist *skypespaces*`<br/> For more info: https://docs.microsoft.com/powershell/module/exchange/organization/Set-OrganizationConfig?view=exchange-ps <br/> |5/30/17  <br/>|
+|Users can't access Meetings/Connectors but have Exchange Online mailboxes. <br/> |Customer actively blocks EWS from services within Exchange Online but needs to have MS Teams compliant within EWS policies. <br/> |To make MS Teams compliant, you must add the following User Agent Strings for MS Teams within the EWSAllowList: `*skypespaces*` and `*microsoftninja*`, including asterisks. The following command can be used: `Set-organizationconfig -EwsAllowList @{Add="*MicrosoftNinja*","*SkypeSpaces*"}`<br/> For more info: https://docs.microsoft.com/powershell/module/exchange/organization/Set-OrganizationConfig?view=exchange-ps <br/> |5/30/17  <br/>|
 
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|


### PR DESCRIPTION
Hi,
I purpose a change to the line #161 as our internal information mentions both Strings actually. This is also confirmed on our internal info by the SfB/Teams EEE - Roman Maddox, and Teams Senior SEE - Carolyn Blanding.

Additionally, on the powershell cmdlet that was added before, it would in fact replace the ENTIRE EWSAllowList, with just *skypespaces* this can be very very critical to the customer's environment as we won't have a way to recover what he had before!

The cmdlet I added: Set-organizationconfig -EwsAllowList @{Add="*MicrosoftNinja*","*SkypeSpaces*"} ;
Is effectively just **adding** those 2 strings, instead of **replacing** in its entirety.

Note: this type of issue is arising more and more, and we're getting multiple tickets which lead to confusion when we discuss it with the customers and direct them here, where only *skypespaces* is mentioned (which won't fix the meeting access issue).