### PR TITLE
Remove links to 2015 blog

### DIFF
--- a/Skype/SfbServer/management-tools/statistics-manager/deploy.md
+++ b/Skype/SfbServer/management-tools/statistics-manager/deploy.md
@@ -298,7 +298,4 @@ For more information, see the following:
 - [Upgrade Statistics Manager for Skype for Business Server](upgrade.md)
     
 - [Troubleshoot Statistics Manager for Skype for Business Server](troubleshoot.md)
-    
-- [Skype for Business Server Statistics Manager blog](https://blogs.technet.microsoft.com/skypestatsman/)
-    
-
+ß

--- a/Skype/SfbServer/management-tools/statistics-manager/plan.md
+++ b/Skype/SfbServer/management-tools/statistics-manager/plan.md
@@ -176,7 +176,3 @@ For more information, see the following:
 - [Upgrade Statistics Manager for Skype for Business Server](upgrade.md)
 
 - [Troubleshoot Statistics Manager for Skype for Business Server](troubleshoot.md)
-
-- [Skype for Business Server Statistics Manager blog](https://blogs.technet.microsoft.com/dodeitte/2015/10/24/skype-for-business-server-real-time-statistics-manager)
-
-

--- a/Skype/SfbServer/management-tools/statistics-manager/troubleshoot.md
+++ b/Skype/SfbServer/management-tools/statistics-manager/troubleshoot.md
@@ -172,7 +172,3 @@ For more information, see the following:
 - [Deploy Statistics Manager for Skype for Business Server](deploy.md)
     
 - [Upgrade Statistics Manager for Skype for Business Server](upgrade.md)
-    
-- [Skype for Business Server Statistics Manager blog](https://blogs.technet.microsoft.com/dodeitte/2015/10/24/skype-for-business-server-real-time-statistics-manager)
-    
-

--- a/Skype/SfbServer/management-tools/statistics-manager/upgrade.md
+++ b/Skype/SfbServer/management-tools/statistics-manager/upgrade.md
@@ -106,7 +106,3 @@ For more information, see the following:
 - [Deploy Statistics Manager for Skype for Business Server](deploy.md)
     
 - [Troubleshoot Statistics Manager for Skype for Business Server](troubleshoot.md)
-    
-- [Skype for Business Server Statistics Manager blog](https://blogs.technet.microsoft.com/dodeitte/2015/10/24/skype-for-business-server-real-time-statistics-manager)
-    
-


### PR DESCRIPTION
Removed link to [2015 blog post](https://blogs.technet.microsoft.com/dodeitte/2015/10/24/skype-for-business-server-real-time-statistics-manager/) after cross-checking that more accurate/up-to-date info is already included on remaining links.

https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/1226