### PR TITLE
Remove O365E1 from supported plan

### DIFF
--- a/Teams/teams-live-events/plan-for-teams-live-events.md
+++ b/Teams/teams-live-events/plan-for-teams-live-events.md
@@ -23,7 +23,7 @@ When you are planning Teams live events to hold large meetings in your organizat
 The following prerequisites are required for the user to schedule a Teams live event.
 
 Here are the licenses that must be assigned:  
-- An Office 365 Enterprise E1, E3, or E5 license or an Office 365 A3 or A5 license. 
+- An Office 365 Enterprise E3 or E5 license or an Office 365 A3 or A5 license. 
 - A Microsoft Teams, Skype for Business, and Microsoft Stream license.
 
 It's important to know that an Office 365 license is required to participate in a live event as an authenticated user but this depends on the production method used:


### PR DESCRIPTION
Live Event with Teams is seems not to be supported O365 E1 plan. So would you remove from the document to prevent confusion?

From another public document, Office E3/E5 is only supported plan for live event.
https://support.office.com/en-us/article/d077fec2-a058-483e-9ab5-1494afda578a

And from another internal FAQ document, Live Event of Teams is supported E3/E5, not E1.
https://microsoft.sharepoint.com/sites/Infopedia_G03KC/KCDOCs/Forms/AllItems.aspx?id=%2Fsites%2FInfopedia_G03KC%2FKCDOCs%2FEmployee%20Engagement%20Resources%2FFAQ%20for%20Live%20Events.docx&parent=%2Fsites%2FInfopedia_G03KC%2FKCDOCs%2FEmployee%20Engagement%20Resources&embed=%7B%22o%22%3A%22https%3A%2F%2Fmicrosoft.sharepoint.com%22%2C%22id%22%3A%222f03be37-e62a-97bc-864b-2667668b7fb4%22%2C%22af%22%3Atrue%7D