### PR TITLE
Updated info about Premium Rate

### DIFF
--- a/Teams/country-and-region-availability-for-audio-conferencing-and-calling-plans/availability-in-france.md
+++ b/Teams/country-and-region-availability-for-audio-conferencing-and-calling-plans/availability-in-france.md
@@ -57,7 +57,7 @@ Here are the Office 365 services for Skype for Business and Microsoft Teams avai
 |:-----|:-----|
 |Calling Plans are available to purchase?  <br/> |Yes  <br/> |
 |Minutes available for Calling Plans. |There are four plan options available per calendar month: <ul><li>120 minute Domestic Calling Plan </li><li>240 minute Domestic Calling Plan</li></li><li>1200 minute Domestic Calling Plan </li></li><li>Domestic and International Calling Plan:  1200 minutes of domestic -OR- 600 minutes of international calling (whichever is reached first in the calendar month)</li></li> 
-|Can make outbound calls to premium numbers? <br/> | Yes, fully supported at this time. <br/> |
+|Can make outbound calls to French premium numbers? <br/> | Yes, fully supported when using Communications Credits to pay per minute. <br/> |
 |Can make outbound calls to?  <br/> | To 196 countries, including [these](users-can-make-outbound-calls-to-these-countries-and-regions.md).<br/> |
    
 ## Toll and toll-free numbers for services


### PR DESCRIPTION
Added that you need Communications Credits to pay per minute for calls to Premium Rate numbers in France as customers have been unclear on the need to pay for those calls outside their package.