### PR TITLE
Update teams-and-skypeforbusiness-coexistence-and-interoperability.md

### DIFF
--- a/Teams/teams-and-skypeforbusiness-coexistence-and-interoperability.md
+++ b/Teams/teams-and-skypeforbusiness-coexistence-and-interoperability.md
@@ -60,6 +60,8 @@ A **Teams only** user can only use the Skype for Business client to join existin
 
 ![Skype for Business client running in a special mode after the user is upgraded as a Teams-only user](media/teams-and-skypeforbusiness-coexistence-and-interop-image1.png "Skype for Business client running in a special mode after the user is upgraded as a Teams-only user")
 
+###[WE NEED SOMETHING HERE ABOUT SfB client versions that support TeamsUpgrade mode and the various feature limitiations by build.]
+
 ### Skype for Business with Teams Collaboration (this mode is upcoming)
 
 Use this mode to introduce Teams in your environment while you continue to leverage your existing investment in Skype for Business. In this mode, you leave Skype for Business unchanged with chat, calling, and meeting capabilities, and you add Teams collaboration capabilities—teams and channels, access to files in Office 365, and applications. Organizations with starting point of Skype for Business server on premises or hybrid should use this mode instead of Islands mode.


### PR DESCRIPTION
I propose that we need to add, after the upgrade image that appears at line 61 (inserted need at line 63), information regarding what SfB clients support the Teams upgrade mode.  My understanding is that there are some SfB clients that support Screenshare with TeamsOnly users and others that do not.  Feature by Feature build requirements change so we definitely need to publish something about these build requirements.

For example, my SfB client doesn't have same image as identified in this doc and it doesn't let me join SfB meetings from it that were scheduled by SfB users.  Mine tenant's TeamsOnly user's SfB says "SfB has been upgraded to Teams! Everything's updated and ready for you.  Start using Teams".  The SfB meetings only give me a link to join online.  I'm on office version 1803 (build 9126.2336 click to run).

I have a customer whose SfB is a half client (even though he is TeamsOnly mode) he has SfB 2016 MSO (16.0.8201.2193) 32bit - Office version 1705 (build 8201.2193 click to run).  That customer doesn't even see the Teamsupgrade message.