### PR TITLE
Update Meeting Limitation for Kiosk Workers

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -42,6 +42,8 @@ Meetings and calls
 |Number of people in a meeting  | 250    |
 |Number of people in a private chat  | 50    |
 
++ Kiosk workers will not have the ability to schedule Teams Meetings, as by default, AllowChannelMeetingScheduling and AllowPrivateMeetingScheduling are not included with inband provisioning in respect to the TeamsMeetingPolicy. This only applies to Kiosk workers. 
+
 Storage
 -------
 

--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -42,7 +42,8 @@ Meetings and calls
 |Number of people in a meeting  | 250    |
 |Number of people in a private chat  | 50    |
 
-+ Kiosk workers will not have the ability to schedule Teams Meetings, as by default, AllowChannelMeetingScheduling and AllowPrivateMeetingScheduling are not included with inband provisioning in respect to the TeamsMeetingPolicy. This only applies to Kiosk workers. 
+> [!IMPORTANT]
+> Kiosk workers will not have the ability to schedule Teams Meetings, as by default, AllowChannelMeetingScheduling and AllowPrivateMeetingScheduling are not included with inband provisioning in respect to the TeamsMeetingPolicy. This only applies to Kiosk workers. 
 
 Storage
 -------


### PR DESCRIPTION
Kiosk workers will not have the ability to schedule Teams Meetings, as by default, AllowChannelMeetingScheduling and AllowPrivateMeetingScheduling are not included with inband provisioning in respect to the TeamsMeetingPolicy. This only applies to Kiosk workers.