### PR TITLE
Fix SQL syntax

### DIFF
--- a/Skype/SfbServer/management-tools/call-quality-dashboard/deploy-0.md
+++ b/Skype/SfbServer/management-tools/call-quality-dashboard/deploy-0.md
@@ -311,12 +311,12 @@ Examples
 INSERT INTO
 [dbo].[CqdBuildingOwnershipType]
 ([OwnershipTypeId],
-[OwnershipTypeDesc],
+[OwnershipTypeDesc]
 )
 
 VALUES
 (1,
-'Contoso Owned',
+'Contoso Owned'
 )
 ```
 


### PR DESCRIPTION
Fixes #1527. Removes commas before closing parentheses in a block of sample SQL code.