### PR TITLE
Update Exchange-Teams-interact.md

### DIFF
--- a/Teams/Exchange-Teams-interact.md
+++ b/Teams/Exchange-Teams-interact.md
@@ -34,12 +34,14 @@ The following table provides information for users with Exchange Online hosted i
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 |**Exchange Online**|Yes<sup>2</sup>|Yes<sup>2</sup>|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|
 |**Exchange Online Dedicated vNext**|Yes<sup>2</sup>|Yes<sup>2</sup>|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|
-|**Exchange Online Dedicated – Legacy** (Sync to Azure AD required)|Yes <sup>2</sup>|Yes<sup>2, 3</sup>|No|Yes|No|No|Yes|Yes|No|No|No|Yes|Yes|
-|**Exchange on-premises** (Sync to Azure AD required)|Yes <sup>2</sup>|Yes<sup>2, 3</sup>|No|Yes|Yes(Exchange 2016 CU3+)|No|Yes|Yes|No|No|No|No|Yes|
+|**Exchange Online Dedicated – Legacy** (Sync to Azure AD required)|Yes <sup>2</sup>|Yes<sup>2, 3</sup>|Yes<sup>4|Yes|No|No|Yes|Yes|No|No|No|Yes|Yes|
+|**Exchange on-premises** (Sync to Azure AD required)|Yes <sup>2</sup>|Yes<sup>2, 3</sup>|Yes<sup>4|Yes|Yes(Exchange 2016 CU3+)|No|Yes|Yes|No|No<sup>5|No|No|Yes|
                                                             
 <sup>1</sup> Exchange 2016 CU3 and above supported  
 <sup>2</sup> eDiscovery and Legal Hold for compliance on channel messages is supported for all hosting options.  
 <sup>3</sup> Teams private chat messages are not yet supported for Legal Hold for this hosting option.
+<sup>4</sup> Retention will use a shadow mailbox for the online user to store messages. [Microsoft Teams Supports eDiscover for Teams user in an Exchange Hybrid environment](https://techcommunity.microsoft.com/t5/Microsoft-Teams-Blog/Microsoft-Teams-supports-eDiscovery-for-Teams-users-in-a/ba-p/200009).
+<sup>4</sup> Teams users with on premise Exchange mailbox may use voicemail with Teams and receive voicemail messages in Outlook, but voicemail messages will not be avaiable to view or play within the Teams client.
 
 Additional information:
 
@@ -55,7 +57,7 @@ Additional information:
 
 -   In Microsoft Teams, security and compliance features like eDiscovery, Content Search, archiving, and legal hold work best in Exchange Online and SharePoint Online environments. For channel conversations, messages are journaled to the group mailbox in Exchange Online, where they're available for eDiscovery. If SharePoint Online and OneDrive for Business (using work or school account) are enabled across the organization and for users, these compliance features are available for all files within Teams as well.
 
--   For Exchange on-premises (hybrid deployment), you need to configure OAuth as described in [Configure OAuth authentication between Exchange and Exchange Online organizations](https://technet.microsoft.com/en-us/library/dn594521(v=exchg.150).aspx). 
+-   For Exchange on-premises, you must to configure OAuth as described in [Configure OAuth authentication between Exchange and Exchange Online organizations](https://technet.microsoft.com/en-us/library/dn594521(v=exchg.150).aspx). 
 
 > [!NOTE]
 > Currently, if your organization has compliance requirements to ensure all meeting discussions are discoverable, you should disable private meetings if the organizer has an Exchange on-premises mailbox.


### PR DESCRIPTION
Updated table:
1. Change Retention support to Yes with supplemental information item 3 for on dedicated and on premise exchange.
2. Added supplemental information note 4 for voicemail to provide more context. Voicemail is supported in Teams regardless of mailbox location, but voicemail messages will not be available in Teams for on premise mailbox. 
3. Removed (hybrid configuration) for requirement for Oauth for Exchange on-premise. Oauth MUST be configured so that exchange on premise allow Outh authenticated connection to EWS from Teams Middle Tier Service. HOWEVER, Houston we have a problem, the Exchange article we are referencing has the WRONG authserver configuration. Teams service will present a token from Azure AD (evoSTS) and that needs to be configured in Exchange on premise for authentication to be successful. Without this, connectivity to mailboxes to access user data will fail. I put in a github request to have that article updated but not sure if that will get processed. If you could put in a word to that team, that would be awesome.