### PR TITLE
Update get-clients.md

### DIFF
--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -146,29 +146,36 @@ Sample PowerShell Script
 This sample script, which needs to run on client computers in the context of an elevated administrator account, will create a new inbound firewall rule for each user folder found in c:\users. When Teams finds this rule, it will prevent the Teams application from prompting users to create firewall rules when the users make their first call from Teams. 
 
 ```
-$users = Get-Childitem c:\users
-foreach ($user in $users) 
-{
-    $Path = "c:\users\" + $user.Name + "\appdata\local\Microsoft\Teams\Current\Teams.exe"
-    if (Test-Path $Path) 
-	{
-	        $name = "teams.exe " + $user.Name
-	        if (!(Get-NetFirewallRule -DisplayName $name))
-		{
-	            New-NetFirewallRule -DisplayName “teams.exe” -Direction Inbound -Profile Domain -Program $Path -Action Allow
-		}
-	}
-}
+
 <#
-        .ABOUT THIS SCRIPT
-        (c) Microsoft Corporation 2018. All rights reserved. Script provided as-is without any warranty of any kind. Use it freely at your own risks.
-
-        Must be run with elevated permissions. Can be run as a GPO Computer Startup script, or as a Scheduled Task with elevated permissions. 
-
-        The script will create a new inbound firewall rule for each user folder found in c:\users. 
-
-        Requires PowerShell 3.0
-        
+.Synopsis
+   Creates firewall rules for Teams.
+.DESCRIPTION
+   (c) Microsoft Corporation 2018. All rights reserved. Script provided as-is without any warranty of any kind. Use it freely at your own risks.
+   Must be run with elevated permissions. Can be run as a GPO Computer Startup script, or as a Scheduled Task with elevated permissions. 
+   The script will create a new inbound firewall rule for each user folder found in c:\users. 
+   Requires PowerShell 3.0.
 #>
+
+#Requires -Version 3
+
+$users = Get-ChildItem (Join-Path -Path $env:SystemDrive -ChildPath 'Users') -Exclude 'Public', 'ADMINI~*'
+if ($users.Length -gt 0)
+{
+    foreach ($user in $users)
+    {
+        $progPath = Join-Path -Path $user.FullName -ChildPath "AppData\Local\Microsoft\Teams\Current\Teams.exe"
+        if (Test-Path $progPath)
+	    {
+	        if (-not (Get-NetFirewallApplicationFilter -Program $progPath -ErrorAction SilentlyContinue))
+		    {
+                $ruleName = "Teams.exe for user $($user.Name)"
+                "UDP", "TCP" | ForEach-Object { New-NetFirewallRule -DisplayName $ruleName -Direction Inbound -Profile Domain -Program $progPath -Action Allow -Protocol $_ }
+                Clear-Variable ruleName
+		    }
+	    }
+        Clear-Variable progPath
+    }
+}
 
 ```


### PR DESCRIPTION
Updated the PowerShell script. I know it says it's a sample, but why not present a more robust sample? :)
Added synopsis and a bit more robustness. Specifies requires PS version 3, excludes local admins and Public users, looks for a firewall rule containing the path to Teams.exe for the users instead of a firewall rule name. Specifies TCP and UDP port instead of allowing all ports.