### PR TITLE
Update Known-issues.md

### DIFF
--- a/Teams/Known-issues.md
+++ b/Teams/Known-issues.md
@@ -3,7 +3,7 @@ title: Known issues for Microsoft Teams
 author: LolaJacobsen
 ms.author: lolaj
 manager: serdars
-ms.date: 8/21/2018
+ms.date: 2/19/2019
 ms.topic: article
 ms.service: msteams
 ms.collection: Teams_ITAdmin_Help
@@ -267,7 +267,7 @@ This article lists the known issues for Microsoft Teams, by feature area.
 
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|
-|Team member maximum of 2500  <br/> |Each Microsoft Team can have a maximum of 2500 members per team.  <br/> |No workaround.  <br/> |3/13/17  <br/> |
+|Team member maximum of 5000  <br/> |Each Microsoft Team can have a maximum of 5000 members per team.  <br/> |No workaround.  <br/> |2/6/2019  <br/> |
 
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|


### PR DESCRIPTION
The Team limit was doubled from 2500 to 5000 members publically on 2/06/2019.
Reference the Uservoice announcement here: 
https://microsoftteams.uservoice.com/forums/555103-public/suggestions/31930651-increase-user-limit-above-2500

We've also changed it on the "Limits and specifications for Microsoft Teams" article as well: https://docs.microsoft.com/en-us/microsoftteams/limits-specifications-teams