### PR TITLE
Update see-change-and-reset-a-conference-id-assigned-to-a-user.md

### DIFF
--- a/Skype/SfbOnline/audio-conferencing-in-office-365/see-change-and-reset-a-conference-id-assigned-to-a-user.md
+++ b/Skype/SfbOnline/audio-conferencing-in-office-365/see-change-and-reset-a-conference-id-assigned-to-a-user.md
@@ -85,7 +85,7 @@ You can reset a conference ID for a user if, for example, they forget it.
 You can reset the conference ID for a user by using the Windows PowerShell. To do this, run:
 
   ```
-  Set-CsOnlineDialInConferencingUser -Identity "Amos Marble"  -ResetConferenceID 8271964
+  Set-CsOnlineDialInConferencingUser -Identity "Amos Marble" -ResetConferenceID
   ```
 
 ## What else should you know?


### PR DESCRIPTION
-ResetConferenceId is a switch parameter, you cannot specify a value. To set a specific conference id you should use -ConferenceId xxxxxxxx.
Reference:
https://docs.microsoft.com/powershell/module/skype/set-csonlinedialinconferencinguser