### PR TITLE
Update plan-for-teams-live-events.md

### DIFF
--- a/Teams/teams-live-events/plan-for-teams-live-events.md
+++ b/Teams/teams-live-events/plan-for-teams-live-events.md
@@ -37,7 +37,7 @@ For more information on licensing, see [Microsoft Teams add-on licensing](../tea
 The user must have:
 - Private meeting scheduling in Teams enabled (*The TeamsMeetingPolicy -AllowPrivateMeetingScheduling parameter = True*).
 - Video sharing enabled in Teams meetings (*The TeamsMeetingPolicy -AllowIPVideo parameter = True*).
-- Screen sharing enabled in Teams meetings (*The TeamsMeetingPolicy -ScreenSharingMode parameter = Desktop*).
+- Screen sharing enabled in Teams meetings (*The TeamsMeetingPolicy -ScreenSharingMode parameter = EntireScreen*).
 - Live event scheduling in Teams enabled (*The TeamsMeetingBroadcastPolicy -AllowBroadcastScheduling parameter = True*).
 - Permissions to create live events in Microsoft Stream (for [external encoder production](#production)).
 


### PR DESCRIPTION
I am getting an error when trying to set the ScreenSharingMode to Desktop, this option isn't available anymore. 
Invalid value for "ScreenSharingMode". Possible values are: Disabled,SingleApplication,EntireScreen.
    + CategoryInfo          : InvalidArgument: (Microsoft.Rtc.M...msMeetingPolicy:TeamsMeetingPolicy) [Set-CsTeamsMeet
   ingPolicy], ArgumentException
    + FullyQualifiedErrorId : CustomValidationFailed,Microsoft.Rtc.Management.Internal.SetTeamsMeetingPolicyCmdlet
    + PSComputerName        : admingb1.online.lync.com

So that's why I adjusted this text.

I adjusted the text to use EntireScreen as the option:
https://docs.microsoft.com/en-us/powershell/module/skype/set-csteamsmeetingpolicy?view=skype-ps