### PR TITLE
Remove reference to 'user cohorts'

### DIFF
--- a/Teams/upgrade-to-Teams-execute-SkypeforBusinessOnline.md
+++ b/Teams/upgrade-to-Teams-execute-SkypeforBusinessOnline.md
@@ -56,36 +56,6 @@ Follow these steps to upgrade all of your users to Teams at one time.
 1. In the Microsoft Teams admin center, select **Org-wide settings**.
 2. Select **Teams Only** mode from the **Coexistence mode** drop-down list.
 
-## Upgrade users in stages
-
-Follow these steps if you want to gradually upgrade your users to Teams.
-
-### Step 1: Create your user cohorts for the upgrade
-
-User cohorts are groups of users who will be moved to Teams Only mode at the same time.
-
-To create your user cohorts (Add link to user selection page)
-
-### Step 2: Set the user mode to Islands
-
-1. In the Microsoft Teams admin center, select **Users**, and then select a user cohort.
-2. Next to **Teams upgrade**, select **Edit**.
-3. In the **Teams Upgrade** pane, under **Coexistence mode**, select **Islands** from the drop-down list.
-
-### Step 3: Set notification for the user (optional)
-
-1. In the Microsoft Teams admin center, select **Users**, and select a user cohort.
-2. Next to **Teams upgrade**, select **Edit**.
-3. In the **Teams Upgrade** pane, under **Coexistence mode**, change **Notify the Skype for Business user** switch to **On**.
-
-### Step 4: Set the user mode to Teams Only
-
-When you are ready to upgrade the users to use Teams as their only application, set the Coexistence mode for the user to Teams Only.
-
-1. In the Microsoft Teams admin center, select **Users**, and then select a user cohort.
-2. Next to **Teams upgrade**, select **Edit**.
-3. In the **Teams Upgrade** pane, under **Coexistence mode**, select **Teams Only** from the drop-down list.
-
 ## Phone System and Teams upgrade
 
 If your Skype for Business Online deployment includes Phone System with Calling Plans and Microsoft is your public switched telephone network (PSTN) provider, upgrading your users to Teams will automatically transition inbound PSTN calling to Teams.


### PR DESCRIPTION
The removed section referred to user cohorts, which I assume was some proposed feature to group together users and set their co-existence mode. Remove this section as there is no such thing as a user cohort.