### PR TITLE
Removed an unnecessary reference to PSTN IP

### DIFF
--- a/Skype/SfbServer/plan-your-deployment/network-requirements/ip-address-types.md
+++ b/Skype/SfbServer/plan-your-deployment/network-requirements/ip-address-types.md
@@ -46,7 +46,7 @@ Using Topology Builder, perform the steps in the following procedure to deploy I
    - **PSTN IP address**. Define a PSTN IP address when a Mediation Server is collocated on the Front End Server. This address must match the format of the selected address type.
 
 > [!NOTE]
-> The installation of additional network interface cards (NICs) to support the PSTN IP address configuration on Front End Servers is not supported. For more information about supported NIC configurations for Skype for Business Server, see [Server hardware platforms for Lync Server 2013](https://technet.microsoft.com/library/c964c1c0-0153-472b-88ad-a38866e0df0c.aspx).
+> The installation of additional network interface cards (NICs) on Front End Servers is not supported. For more information about supported NIC configurations for Skype for Business Server, see [Server hardware platforms for Lync Server 2013](https://technet.microsoft.com/library/c964c1c0-0153-472b-88ad-a38866e0df0c.aspx).
 
 ## Deploy IP address types on a Mediation Server
 

--- a/Skype/SfbServer/plan-your-deployment/network-requirements/ip-address-types.md
+++ b/Skype/SfbServer/plan-your-deployment/network-requirements/ip-address-types.md
@@ -46,7 +46,7 @@ Using Topology Builder, perform the steps in the following procedure to deploy I
    - **PSTN IP address**. Define a PSTN IP address when a Mediation Server is collocated on the Front End Server. This address must match the format of the selected address type.
 
 > [!NOTE]
-> The installation of additional network interface cards (NICs) on Front End Servers is not supported. For more information about supported NIC configurations for Skype for Business Server, see [Server hardware platforms for Lync Server 2013](https://technet.microsoft.com/library/c964c1c0-0153-472b-88ad-a38866e0df0c.aspx).
+> The installation of additional network interface cards (NICs) to support the PSTN IP address configuration (or for any other reason) on Front End Servers is not supported. For more information about supported NIC configurations for Skype for Business Server, see [Server hardware platforms for Lync Server 2013](https://technet.microsoft.com/library/c964c1c0-0153-472b-88ad-a38866e0df0c.aspx).
 
 ## Deploy IP address types on a Mediation Server
 


### PR DESCRIPTION
Removed an unnecessary reference to PSTN IP in the multi-homed note, which made it too specific.