### PR TITLE
User can now set a custom status presence #1943

### DIFF
--- a/Teams/presence-admins.md
+++ b/Teams/presence-admins.md
@@ -59,7 +59,6 @@ The following Admin settings in Skype for Business are different in Teams:
 - Client Do Not Disturb and Breakthrough features are always enabled for users in Teams.
 - Calendar (includes OOF & other calendar info) integration  is always enabled for users in Teams if integrated with Outlook.
 - The *Last seen* or *Away since* (if in a dual environment with Skype for Business) indicator is always enabled for users in Teams.
-- Setting a custom presence status is not enabled for users in Teams.
 
 > [!NOTE]
 > The ability of a Teams Admin to customize these settings is not currently supported.


### PR DESCRIPTION
Removed line 62 "Setting a custom presence status is not enabled for users in Teams." as Users can now select their picture (or picture placeholder), and select Set status message. Resolves #1943