### PR TITLE
Update mobile-feature-comparison.md

### DIFF
--- a/Skype/SfbServer/plan-your-deployment/clients-and-devices/mobile-feature-comparison.md
+++ b/Skype/SfbServer/plan-your-deployment/clients-and-devices/mobile-feature-comparison.md
@@ -172,6 +172,7 @@ On iOS devices, Skype for Business signs out automatically after the mobile clie
  &#x2776;  For Office 365 users, this feature requires Enterprise Voice, which is part of the E5 license.
   
  &#x2777;  Requires a WiFi connection by default.
+ 
  &#x2778;  Viewing embedded video in PowerPoint presentations is not supported.
   
 ## Telephony support

--- a/Skype/SfbServer/plan-your-deployment/clients-and-devices/mobile-feature-comparison.md
+++ b/Skype/SfbServer/plan-your-deployment/clients-and-devices/mobile-feature-comparison.md
@@ -161,7 +161,7 @@ On iOS devices, Skype for Business signs out automatically after the mobile clie
 |Access detailed meeting roster for IM conferences  <br/> |&#x2714;|&#x2714;|&#x2714;|&#x2714;|
 |Share desktop or program  <br/> |&#x2714;||||
 |View shared desktop or program (VbSS or RDP)  <br/> |&#x2714;|&#x2714; &#x2777; |&#x2714; &#x2777; |&#x2714; &#x2777; |
-|View shared PowerPoint files  <br/> |&#x2714;|&#x2714; &#x2777; |&#x2714; &#x2777; |&#x2714; &#x2777; |
+|View shared PowerPoint files  <br/> |&#x2714;|&#x2714; &#x2777; |&#x2714; &#x2777;&#x2778; |&#x2714; &#x2777; &#x2778;|
 |Upload and present PowerPoint files  <br/> |&#x2714;||&#x2714; &#x2777; |&#x2714; &#x2777; |
 |Use meeting tools (use whiteboard, conduct polls, share files)  <br/> |&#x2714;||||
 |Navigate a list of your meetings  <br/> |&#x2714;|&#x2714;|&#x2714;|&#x2714;|
@@ -172,6 +172,7 @@ On iOS devices, Skype for Business signs out automatically after the mobile clie
  &#x2776;  For Office 365 users, this feature requires Enterprise Voice, which is part of the E5 license.
   
  &#x2777;  Requires a WiFi connection by default.
+ &#x2778;  Viewing embedded video in PowerPoint presentations is not supported.
   
 ## Telephony support
 


### PR DESCRIPTION
-added &#x2778  (number3)
- Added: Viewing embedded video in PowerPoint presentations is not supported.
#1789 
See UserVoice:
The ios Skype for business client (Phone and ipad) does not play videos embedded in PowerPoint. This has been confirmed by Microsoft support

https://www.skypefeedback.com/forums/299913-generally-available/suggestions/31537219-the-ios-skype-for-business-client-phone-and-ipad
https://www.skypefeedback.com/forums/299913-generally-available/suggestions/35314720-powerpoint-sharing-error-in-android-app