### PR TITLE
Added and clarify the monthly billing #1790

### DIFF
--- a/Teams/set-up-communications-credits-for-your-organization.md
+++ b/Teams/set-up-communications-credits-for-your-organization.md
@@ -71,6 +71,8 @@ For more information, see [Microsoft Teams add-on licensing](teams-add-on-licens
 
       > [!NOTE]
      > Funds will be applied only to Communications Credits at Microsoft published rates when the services are used. Any funds not used within 12 months of the purchase date will expire and be forfeited. 
+     > 
+     > Monthly billing for Communication Credits will only be applied if the alloted fund has been used, to check on your monthly usage we recommend to view [Skype for Business PSTN usage report](https://docs.microsoft.com/en-us/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
     
 5. Enter your payment information and click **Place order**.
     >[!IMPORTANT]
@@ -78,7 +80,7 @@ For more information, see [Microsoft Teams add-on licensing](teams-add-on-licens
     
 Each organization will have a different usage of Calling Plan volume and rates to consider. You will need to get this type of usage data from your current service provider. Organizations already using Skype for Business Online already as their service provider can get usage data by reviewing it in the **Skype for Business admin center** > **Reports** > **PSTN usage details** report.
   
-When you are setting up Communications Credits, you will need to investigate call usage for your organization to determine the amounts that you will need to put in. You can get call usage information by reviewing the **PSTN usage details** report. This report lets you export the call data records to Excel if you want to export the data for storage or create custom reports. To see usage, see [Skype for Business PSTN usage report](/SkypeForBusiness/skype-for-business-online-reporting/pstn-usage-report)
+When you are setting up Communications Credits, you will need to investigate call usage for your organization to determine the amounts that you will need to put in. You can get call usage information by reviewing the **PSTN usage details** report. This report lets you export the call data records to Excel if you want to export the data for storage or create custom reports. To see usage, see [Skype for Business PSTN usage report](https://docs.microsoft.com/en-us/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
   
 ## Step 3: Assign a Communications Credits license to users
 

--- a/Teams/set-up-communications-credits-for-your-organization.md
+++ b/Teams/set-up-communications-credits-for-your-organization.md
@@ -80,7 +80,7 @@ For more information, see [Microsoft Teams add-on licensing](teams-add-on-licens
     
 Each organization will have a different usage of Calling Plan volume and rates to consider. You will need to get this type of usage data from your current service provider. Organizations already using Skype for Business Online already as their service provider can get usage data by reviewing it in the **Skype for Business admin center** > **Reports** > **PSTN usage details** report.
   
-When you are setting up Communications Credits, you will need to investigate call usage for your organization to determine the amounts that you will need to put in. You can get call usage information by reviewing the **PSTN usage details** report. This report lets you export the call data records to Excel if you want to export the data for storage or create custom reports. To see usage, see [Skype for Business PSTN usage report](https://docs.microsoft.com/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
+When you are setting up Communications Credits, you will need to investigate call usage for your organization to determine the amounts you need. You can get call usage information by reviewing the **PSTN usage details** report. This report lets you export the call data records to Excel if you need to store the data or create custom reports. To learn how to see usage, read [Skype for Business PSTN usage report](https://docs.microsoft.com/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report).
   
 ## Step 3: Assign a Communications Credits license to users
 

--- a/Teams/set-up-communications-credits-for-your-organization.md
+++ b/Teams/set-up-communications-credits-for-your-organization.md
@@ -72,7 +72,7 @@ For more information, see [Microsoft Teams add-on licensing](teams-add-on-licens
       > [!NOTE]
      > Funds will be applied only to Communications Credits at Microsoft published rates when the services are used. Any funds not used within 12 months of the purchase date will expire and be forfeited. 
      > 
-     > Monthly billing for Communication Credits will only be applied if the alloted fund has been used, to check on your monthly usage read [Skype for Business PSTN usage report](https://docs.microsoft.com/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
+     > Monthly billing for Communication Credits will only be applied if the alloted fund has been used, to learn how to check your monthly usage, read [Skype for Business PSTN usage report](https://docs.microsoft.com/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
     
 5. Enter your payment information and click **Place order**.
     >[!IMPORTANT]

--- a/Teams/set-up-communications-credits-for-your-organization.md
+++ b/Teams/set-up-communications-credits-for-your-organization.md
@@ -72,7 +72,7 @@ For more information, see [Microsoft Teams add-on licensing](teams-add-on-licens
       > [!NOTE]
      > Funds will be applied only to Communications Credits at Microsoft published rates when the services are used. Any funds not used within 12 months of the purchase date will expire and be forfeited. 
      > 
-     > Monthly billing for Communication Credits will only be applied if the alloted fund has been used, to check on your monthly usage we recommend to view [Skype for Business PSTN usage report](https://docs.microsoft.com/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
+     > Monthly billing for Communication Credits will only be applied if the alloted fund has been used, to check on your monthly usage read [Skype for Business PSTN usage report](https://docs.microsoft.com/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
     
 5. Enter your payment information and click **Place order**.
     >[!IMPORTANT]

--- a/Teams/set-up-communications-credits-for-your-organization.md
+++ b/Teams/set-up-communications-credits-for-your-organization.md
@@ -72,7 +72,7 @@ For more information, see [Microsoft Teams add-on licensing](teams-add-on-licens
       > [!NOTE]
      > Funds will be applied only to Communications Credits at Microsoft published rates when the services are used. Any funds not used within 12 months of the purchase date will expire and be forfeited. 
      > 
-     > Monthly billing for Communication Credits will only be applied if the alloted fund has been used, to check on your monthly usage we recommend to view [Skype for Business PSTN usage report](https://docs.microsoft.com/en-us/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
+     > Monthly billing for Communication Credits will only be applied if the alloted fund has been used, to check on your monthly usage we recommend to view [Skype for Business PSTN usage report](https://docs.microsoft.com/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
     
 5. Enter your payment information and click **Place order**.
     >[!IMPORTANT]
@@ -80,7 +80,7 @@ For more information, see [Microsoft Teams add-on licensing](teams-add-on-licens
     
 Each organization will have a different usage of Calling Plan volume and rates to consider. You will need to get this type of usage data from your current service provider. Organizations already using Skype for Business Online already as their service provider can get usage data by reviewing it in the **Skype for Business admin center** > **Reports** > **PSTN usage details** report.
   
-When you are setting up Communications Credits, you will need to investigate call usage for your organization to determine the amounts that you will need to put in. You can get call usage information by reviewing the **PSTN usage details** report. This report lets you export the call data records to Excel if you want to export the data for storage or create custom reports. To see usage, see [Skype for Business PSTN usage report](https://docs.microsoft.com/en-us/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
+When you are setting up Communications Credits, you will need to investigate call usage for your organization to determine the amounts that you will need to put in. You can get call usage information by reviewing the **PSTN usage details** report. This report lets you export the call data records to Excel if you want to export the data for storage or create custom reports. To see usage, see [Skype for Business PSTN usage report](https://docs.microsoft.com/skypeforbusiness/skype-for-business-online-reporting/pstn-usage-report)
   
 ## Step 3: Assign a Communications Credits license to users
 


### PR DESCRIPTION
#1790 
The answer to the customer inquiry is:
With Communication Credits, monthly billing depends on their allotted fund usage(metered billing). if for example customer was not able to use it. they still have 12 months before it get's forfeited.

Already written in the article.
"Funds will be applied only to Communications Credits at Microsoft published rates when the services are used. Any funds not used within 12 months of the purchase date will expire and be forfeited."

Action Taken:
-Previous link is not working, added the correct the link:
Skype for Business PSTN usage report
-Added and clarify the monthly billing- "Monthly billing for Communication Credits will only be applied if the alloted fund has been used, to check on your monthly usage we recommend to view"

References:
SfB Broadcast: Ep. 42 Configuring PSTN Consumption Billing in O365 (now it is called Communications Credits )
At 19:59 = EA, discussed about Enterprise Agreement Customer, already written in the article. "Set up Communications Credits for your organization"
https://www.youtube.com/watch?v=wDEjoRG2zeY&list=PLx28OnnzHAl2RTtyPdpFnJRwTsMZpgqC-&index=2

What is communication credit
https://docs.microsoft.com/en-us/microsoftteams/what-are-communications-credits?toc=/skypeforbusiness/toc.json&bc=/skypeforbusiness/breadcrumb/toc.json