### PR TITLE
Update audio-conferencing-pay-per-minute.md

### DIFF
--- a/Teams/audio-conferencing-pay-per-minute.md
+++ b/Teams/audio-conferencing-pay-per-minute.md
@@ -46,21 +46,35 @@ Whereas the Audio Conferencing per-user license offer includes dial-in usage and
 - Outbound calls placed to external phone numbers from within a meeting of your organization.
     
 > [!NOTE]
-> You can find the dial-in and dial-out rates associated to these types of calls by reviewing the **See rates for where you want to call section** in [Audio Conferencing](https://products.office.com/en-us/microsoft-teams/online-meeting-solutions#Rates).
+> You can find the dial-in and dial-out rates associated to these types of calls by reviewing the **See rates for where you want to call section** in [Audio Conferencing](https://products.office.com/microsoft-teams/online-meeting-solutions#Rates).
   
 Pay-per-minute requires your organization to have [Communications Credits](what-are-communications-credits.md) enabled with a license assigned to each user in order for Audio Conferencing to work. If you want more details, see [Set up Communications Credits for your organization](set-up-communications-credits-for-your-organization.md) and/or [Microsoft Teams add-on licensing](teams-add-on-licensing/microsoft-teams-add-on-licensing.md).
   
 To enable Audio Conferencing pay-per-minute for users in your organization, see [Try or purchase Audio Conferencing in Office 365](try-or-purchase-audio-conferencing-in-office-365-for-teams.md).
+
+## Why is it best for you?
+
+- Pay per-minute will only be charged on a per-minute basis for each inbound or outbound call placed by each attendee during a scheduled meeting (rates vary for toll or toll-free call and by destination) instead of using Skype for Business or Teams application in a mobile device or PC.
+
+- Capability to manage cost since admins can control to restrict the types of dial-outs (international and domestic) that can be done from the meetings of an organizer. See [Outbound calling restriction policies for Audio Conferencing and user PSTN calls](https://docs.microsoft.com/skypeforbusiness/audio-conferencing-in-office-365/outbound-calling-restriction-policies)
+
+- If you have Audio Conferencing pay-per-minute licenses, you don't have to assign Communications Credits licenses separately to each user specifically for Audio Conferencing usage (you might still need to assign them for other services).
+
+- Control and monitor pay-per minute charges by using Communications Credits.
+
+- More flexibility in pricing for customers who don't need all users on a subscription basis. 
+
+- Enable Audio Conferencing pay-per-minute along with a monthly subscription of E5 or a standalone Audio Conferencing subscription, both services will continue to work the same way. Changes will have no effect on the operations of Audio Conferencing or Communications Credits.
   
 ## Want to find out more about pricing?
 
  **Looking for prices?** See [How to see prices and buy add-on licenses](teams-add-on-licensing/microsoft-teams-add-on-licensing.md#bkmk_how) or one of the following:
   
-- [Pricing for Audio Conferencing](https://products.office.com/en-us/skype-for-business/audio-conferencing#Requirements)
+- [Pricing for Audio Conferencing](https://products.office.com/skype-for-business/audio-conferencing#Requirements)
     
-- [Pricing for Phone System](https://products.office.com/en-us/skype-for-business/phone-system#Requirements)
+- [Pricing for Phone System](https://products.office.com/skype-for-business/phone-system#Requirements)
     
-- [Pricing for Calling Plans](https://products.office.com/en-us/skype-for-business/pstn-calling-plans#requirements)
+- [Pricing for Calling Plans](https://products.office.com/skype-for-business/pstn-calling-plans#requirements)
     
 ## Related topics
   


### PR DESCRIPTION
#1820 
**Action Taken:**
-Removed Locale from the URL.
Removed Created "Why is it best for you?" and provided all necessary advantages of purchasing Audio Conferencing pay-per-minute licenses, including 
answer to inquiry MicrosoftDocs issue#1820 , that pay per minutes is not being charge for the conference line nor pay per minute times 5 participants.""
It is being charge by each attendee attends the meeting via phone call instead of SFB/ Team Application, but rates vary for toll or toll-free call and by destination."

**_Watched and read the references below to come-up with the resolution &  #advantages:_**

Article:
Try or purchase Audio Conferencing in Office 365 for Skype for Business Online
https://docs.microsoft.com/skypeforbusiness/audio-conferencing-in-office-365/try-or-purchase-audio-conferencing-in-office-365

Audio Conferencing extended to Microsoft Team and pay-per-minute offering added for more options
https://techcommunity.microsoft.com/t5/Skype-for-Business-Blog/Audio-Conferencing-extended-to-Microsoft-Team-and-pay-per-minute/ba-p/110936

Youtube:
SfB Broadcast: Ep. 50 What's new with PSTN Conferencing
https://www.youtube.com/watch?v=bcbE9JSUZ_Y&index=4&list=PLx28OnnzHAl2RTtyPdpFnJRwTsMZpgqC-&t=16s

SfB Broadcast: Ep. 42 Configuring PSTN Consumption Billing in O365
https://www.youtube.com/watch?v=wDEjoRG2zeY&t=1s