### PR TITLE
Update create-an-org-wide-team.md

### DIFF
--- a/Teams/create-an-org-wide-team.md
+++ b/Teams/create-an-org-wide-team.md
@@ -29,30 +29,34 @@ When an org-wide team is created, all global admins are added as team owners and
 
 > [!NOTE]
 > - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in future.
+>
 > - Rooms that aren't a part of a room list, equipment, and resource accounts might be added or synced to the org-wide team. Team owners can easily remove these accounts from the team.
+>
+>-  Only users that have a Teams license will be added automatically in org-wide team, the new users and newly enabled licensed users who get assigned licenses after the team is created will have the option to join org-wide once they login to Teams.
 
 ## Best practices
 To get the most out of your org-wide team, we recommend team owners do the following.
 
-### Allow only team owners to post to the General channel
-Reduce channel noise by having only team owners post to the General channel. Go to the team and click **More options (…)** > **Manage Team**. On the **Settings** tab, click **Member permissions** > select **Only owners can post messages**.
-### Turn off @team and @[team name] mentions
- Reduce @mentions to keep them from overloading the entire organization. Go to the team and click **More options (…)** > **Manage Team**. On the **Settings** tab, click **@mentions** > turn off **Show members the option to @team or @[team name]**. 
-### Automatically favorite important channels
- Favorite important channels to ensure everyone in your organization engages in specific conversations. To learn more, see [Auto-favorite channels for the whole team](https://support.office.com/article/auto-favorite-channels-for-the-whole-team-a948272c-5aa5-429c-863c-4e1e1cd6b0f6).
+- **Allow only team owners to post to the General channel**
+    - Reduce channel noise by having only team owners post to the General channel. Go to the team and click **More options (…)** > **Manage Team**. On the **Settings** tab, click **Member permissions** > select **Only owners can post messages**.
+- **Turn off @team and @[team name] mentions**
+    - Reduce @mentions to keep them from overloading the entire organization. Go to the team and click **More options (…)** > **Manage Team**. On the **Settings** tab, click **@mentions** > turn off **Show members the option to @team or @[team name]**. 
+- **Automatically favorite important channels**
+    - Favorite important channels to ensure everyone in your organization engages in specific conversations. To learn more, see [Auto-favorite channels for the whole team](https://support.office.com/article/auto-favorite-channels-for-the-whole-team-a948272c-5aa5-429c-863c-4e1e1cd6b0f6).
 
-### Remove accounts that might not belong
-Even though members can’t leave an org-wide team, as a team owner, you can manage the team roster by removing accounts that don’t belong. Make sure you use Teams to remove users from your org-wide team.  If you use another way to remove a user, such as the Microsoft 365 admin center or from a group in Outlook, the user might be added back to the org-wide team. 
+- **Remove accounts that might not belong**
+    - Even though members can’t leave an org-wide team, as a team owner, you can manage the team roster by removing accounts that don’t belong. Make sure you use Teams to remove users from your org-wide team.  If you use another way to remove a user, such as the Microsoft 365 admin center or from a group in Outlook, the user might be added back to the org-wide team. 
 
 ## FAQ
 
-### Is there a way to create an org-wide team other than using the Teams client? 
+- **Is there a way to create an org-wide team other than using the Teams client?**
+    - Global admins can only create an org-wide team by using the Teams client. If your organization limits creating teams to using PowerShell, the recommended workaround is to add your global admins to the security group of users who can create a team. For more information, see [Manage who can create Office 365 Groups](https://docs.microsoft.com/office365/admin/create-groups/manage-creation-of-groups). 
+    
+   - If this isn't an option, you can create a public team using PowerShell and add a global admin as the team owner. Then, have the global admin click **˙˙˙ More options** next to the team name, click **Edit team**, and then change the privacy to **Org-wide - Everyone in your organization will be automatically added**. Note that only team owners can access the **Edit team** option and only global admins can see the **Org-wide** option.
 
-Global admins can only create an org-wide team by using the Teams client. If your organization limits creating teams to using PowerShell, the recommended workaround is to add your global admins to the security group of users who can create a team. For more information, see [Manage who can create Office 365 Groups](https://docs.microsoft.com/office365/admin/create-groups/manage-creation-of-groups). 
-
-If this isn't an option, you can create a public team using PowerShell and add a global admin as the team owner. Then, have the global admin click **˙˙˙ More options** next to the team name, click **Edit team**, and then change the privacy to **Org-wide - Everyone in your organization will be automatically added**. Note that only team owners can access the **Edit team** option and only global admins can see the **Org-wide** option.
-
-### Is there a way to convert an existing team to an org-wide team?
-
-Global admins can convert an existing team to an org-wide team editing it in Teams client.
+- **Is there a way to convert an existing team to an org-wide team?**
+   - Global admins can convert an existing team to an org-wide team editing it in Teams client.
 Go to the team name and click More options ...(ellipsis) > Edit team.
+
+ - **Can we exclude groups or users not to be added as a member of an org-wide team?**
+     - If you need to exclude groups/users, create a specific team instead of creating org-wide team.


### PR DESCRIPTION
#1804 
**Action Taken:**
-Added Note that New Users and newly enabled licensed that has teams/sfb users , once they login to Teams they have an option to join Org-wide
-Added question and answer for: Is there a way to create an org-wide team other than using the Teams client? 
-modify listing arrangement of best practices & faq 

**Analysis:**
-Since Teams: Org-wide channel is an automatic way for everyone in an organization to be a part of a team. Currently, there is no option to not exclude a group or a user to be not a member of Org-wide.
- related USERVOICE: "limit who to add in org-wide team
https://microsoftteams.uservoice.com/forums/555103-public/suggestions/37116655-limit-org-wide-teams-to-actual-users-with-licenses

-But luckily, rooms, SH & DL, unlicensed teams/sfb users are not automatically added
-New Users and newly enabled licensed that has teams/sfb users , once they login to Teams they have an option to join Org-wide
-Did this test on my end, there are invalid accounts from On-premises AD, that automatically added in the org-wide team.
See screenshot: https://snag.gy/sKOWYS.jpg
-Did some test on my end, that maybe creating a group policy in security group might be possible to exclude some groups/users, even via powershell - but no success

**References:**
https://office365itpros.com/2018/10/10/org-wide-teams-now-available/
https://gcits.com/org-wide-teams-in-microsoft-teams/
https://regarding365.com/microsoft-teams-org-wide-opinions-f5a5bc91be26