### PR TITLE
Update direct-routing-border-controllers.md

### DIFF
--- a/Teams/direct-routing-border-controllers.md
+++ b/Teams/direct-routing-border-controllers.md
@@ -61,3 +61,5 @@ If you have any questions about SBC certification program for Direct Routing ple
 |                                                                                                                   |      AP 6350           |    &#10004;   |   Pending    |     ECZ8.1m1p6  |                                             
 |                                                                                                                    |      VME           |    &#10004;    |   Pending    |     ECZ8.1m1p6   |
 |                     [TE-SYSTEMS](https://www.anynode.de/anynode-and-microsoft-teams/)                               |     anynode         |     &#10004;   |  &#10004;   |      v3.16.2      |
+
+To give us product feedback about Teams, such as ideas for new features, please visit [Uservoice](https://microsoftteams.uservoice.com)


### PR DESCRIPTION
#1804 
**Action Taken:**
- added reference to uservoice

_Analysis:_
-The answer to user question might not be available to the public because for the devices to be certified and be part of SBC, MS needs to perform an intense test.  
-But it was indicated on the article: " If you have any questions about SBC certification program for Direct Routing please email to drsbccertification@microsoft.com" 
-Can we instead direct the user to email the support or perhaps a uservoice? 

**Related Uservoice link:** https://www.skypefeedback.com/forums/299910-recently-released/suggestions/13732851-expand-skype-certified-devices.