### PR TITLE
Add a known issue

### DIFF
--- a/Teams/Known-issues.md
+++ b/Teams/Known-issues.md
@@ -291,3 +291,4 @@ This article lists the known issues for Microsoft Teams, by feature area.
 |**Issue title**|**Behavior / Symptom**|**Known workaround**|**Discovery date**|
 |:-----|:-----|:-----|:-----|
 |User not recieving welcome email when added administratively  <br/> |When adding a member to a team using PowerShell or the Teams admin center, they are not recieving a welcome email from Microsoft Teams  <br/> |Adding a member from the Teams UI directly will send an email. Currently, there is no workaround doing so administratively.  <br/> |2/12/19  <br/> |
+


### PR DESCRIPTION
Issue:  After editing unable to delete, move or rename files
Behavior: Files cannot be moved or deleted from Teams Files tab immediately after modifying
Known Workaround: This is a known issue and will be fixed in future. As a workaround after modifying please allow sometime before a file is moved/renamed or deleted.