### PR TITLE
Add .blog files to Media Logs section

### DIFF
--- a/Teams/log-files.md
+++ b/Teams/log-files.md
@@ -81,8 +81,12 @@ Media logs contain diagnostic data about audio, video and screen sharing. They a
 
 |Client |Location |
 |---------|---------|
-|Windows     |%appdata%\Microsoft\Teams\media-stack\*.etl         |
+|Windows     |%appdata%\Microsoft\Teams\media-stack\*.blog         |
+|            |%appdata%\Microsoft\Teams\skylib\*.blog
+|            |%appdata%\Microsoft\Teams\media-stack\*.etl         |
 |Mac OSX     |~/Library/Application Support/Microsoft/Teams/media-stack\*.blog         |
+|            |~/Library/Application Support/Microsoft/Teams/skylib\*.blog         |
+
 
 
 Desktop logs


### PR DESCRIPTION
Important files for troubleshooting calling issues:
Adding .blog files under skylib and media-stack folders.