### PR TITLE
Update diagnose-problems-with-the-skype-for-business-online-connector.md

### DIFF
--- a/Skype/SfbOnline/set-up-your-computer-for-windows-powershell/diagnose-problems-with-the-skype-for-business-online-connector.md
+++ b/Skype/SfbOnline/set-up-your-computer-for-windows-powershell/diagnose-problems-with-the-skype-for-business-online-connector.md
@@ -69,9 +69,9 @@ The Skype for Business Online Connector module can be run only under Windows Pow
 ## Modern authentication fails when WinRM Basic authentication has been disabled
 <a name="BKMKWinRMBasicAuth"> </a>
 
-The latest version of the Skype for Business Online Connector module uses modern authentication, but the underlying Windows Remote Management (WinRM) client must be configured to allow Basic authentication.  Modern authentication uses bearer tokens which are usually passed in the *Authorization: Bearer* header, but Windows PowerShell upon which Skype for Business PowerShell is built does not allow for manipulation of this header.   Instead, Skype for Business PowerShell uses the *Authorization: Basic* header to pass the bearer token.
+The latest version of the Skype for Business Online Connector module uses modern authentication, but the underlying Windows Remote Management (WinRM) client must be configured to allow Basic authentication.  Modern authentication uses bearer tokens which are usually passed in the *Authorization: Bearer* header. Windows PowerShell upon which Skype for Business PowerShell is built does not allow for manipulation of this header.  Instead, Skype for Business PowerShell uses the *Authorization: Basic* header to pass the bearer token.
 
-See [Download and install Windows PowerShell](https://docs.microsoft.com/en-us/SkypeForBusiness/set-up-your-computer-for-windows-powershell/download-and-install-windows-powershell-5-1) for instructions on how to enable WinRM for Basic authentication.
+See [Download and install Windows PowerShell](https://docs.microsoft.com/SkypeForBusiness/set-up-your-computer-for-windows-powershell/download-and-install-windows-powershell-5-1) for instructions on how to enable WinRM for Basic authentication.
 
 ## Failed to connect to Live ID Server
 <a name="BKMKFailedConnect"> </a>

--- a/Skype/SfbOnline/set-up-your-computer-for-windows-powershell/diagnose-problems-with-the-skype-for-business-online-connector.md
+++ b/Skype/SfbOnline/set-up-your-computer-for-windows-powershell/diagnose-problems-with-the-skype-for-business-online-connector.md
@@ -28,6 +28,8 @@ This topic provides information that will help you diagnose and resolve problems
     
 - [Import-Module Error caused by incorrect version of Windows PowerShell](diagnose-problems-with-the-skype-for-business-online-connector.md#BKMKIncorrectVersion)
     
+- [Modern authentication fails when WinRM Basic authentication has been disabled](diagnose-problems-with-the-skype-for-business-online-connector.md#BKMKWinRMBasicAuth)
+    
 - [Failed to connect to Live ID Server](diagnose-problems-with-the-skype-for-business-online-connector.md#BKMKFailedConnect)
     
 - [Failed to load Live ID module](diagnose-problems-with-the-skype-for-business-online-connector.md#BKMKFailedLoad)
@@ -64,6 +66,13 @@ The Skype for Business Online Connector module can be run only under Windows Pow
 
 - **Resolution**: The only way to fix this problem is to install Windows PowerShell 3.0, which is available from the Microsoft Download Center at [https://www.microsoft.com/en-us/download/details.aspx?id=34595](https://www.microsoft.com/en-us/download/details.aspx?id=34595).
   
+## Modern authentication fails when WinRM Basic authentication has been disabled
+<a name="BKMKWinRMBasicAuth"> </a>
+
+The latest version of the Skype for Business Online Connector module uses modern authentication, but the underlying Windows Remote Management (WinRM) client must be configured to allow Basic authentication.  Modern authentication uses bearer tokens which are usually passed in the *Authorization: Bearer* header, but Windows PowerShell upon which Skype for Business PowerShell is built does not allow for manipulation of this header.   Instead, Skype for Business PowerShell uses the *Authorization: Basic* header to pass the bearer token.
+
+See [Download and install Windows PowerShell](https://docs.microsoft.com/en-us/SkypeForBusiness/set-up-your-computer-for-windows-powershell/download-and-install-windows-powershell-5-1) for instructions on how to enable WinRM for Basic authentication.
+
 ## Failed to connect to Live ID Server
 <a name="BKMKFailedConnect"> </a>
 

--- a/Skype/SfbOnline/set-up-your-computer-for-windows-powershell/diagnose-problems-with-the-skype-for-business-online-connector.md
+++ b/Skype/SfbOnline/set-up-your-computer-for-windows-powershell/diagnose-problems-with-the-skype-for-business-online-connector.md
@@ -69,7 +69,7 @@ The Skype for Business Online Connector module can be run only under Windows Pow
 ## Modern authentication fails when WinRM Basic authentication has been disabled
 <a name="BKMKWinRMBasicAuth"> </a>
 
-The latest version of the Skype for Business Online Connector module uses modern authentication, but the underlying Windows Remote Management (WinRM) client must be configured to allow Basic authentication.  Modern authentication uses bearer tokens which are usually passed in the *Authorization: Bearer* header. Windows PowerShell upon which Skype for Business PowerShell is built does not allow for manipulation of this header.  Instead, Skype for Business PowerShell uses the *Authorization: Basic* header to pass the bearer token.
+The latest version of the Skype for Business Online Connector module uses modern authentication, but the underlying Windows Remote Management (WinRM) client must be configured to allow Basic authentication.  Modern authentication uses bearer tokens which are usually passed in the *Authorization: Bearer* header. Windows PowerShell, upon which Skype for Business PowerShell is built, does not allow for manipulation of this header.  Instead, Skype for Business PowerShell uses the *Authorization: Basic* header to pass the bearer token.
 
 See [Download and install Windows PowerShell](https://docs.microsoft.com/SkypeForBusiness/set-up-your-computer-for-windows-powershell/download-and-install-windows-powershell-5-1) for instructions on how to enable WinRM for Basic authentication.
 


### PR DESCRIPTION
Adding information about the need to enable WinRM for Basic authentication.  

We had a customer create a group policy that disabled WinRM for their computers and they were no longer able to execute SfBO PS scripts.  They need this documented so they can get an exception from their IT for some of their computers to allow basic auth