### PR TITLE
Added Vietnam to 'no toll number' countries

### DIFF
--- a/Skype/SfbOnline/audio-conferencing-in-office-365/phone-numbers-for-audio-conferencing.md
+++ b/Skype/SfbOnline/audio-conferencing-in-office-365/phone-numbers-for-audio-conferencing.md
@@ -61,7 +61,7 @@ Shared audio conferencing phone numbers are automatically assigned to organizati
 > The country or region location of your organization can be found by signing in to the **Office 365 admin center** and looking under **Organization Profile**. 
   
 > [!CAUTION]
-> Due to limited availability of toll phone numbers in Venezuela, Indonesia, and United Arab Emirates (UAE), organizations from these countries/regions won't have an Audio Conferencing toll number automatically assigned to them. Toll-free numbers from these locations are available depending on available inventory. 
+> Due to limited availability of toll phone numbers in Venezuela, Indonesia, Vietnam, and United Arab Emirates (UAE), organizations from these countries/regions won't have an Audio Conferencing toll number automatically assigned to them. Toll-free numbers from these locations are available depending on available inventory. 
   
 Dedicated audio conferencing phone numbers are service numbers that you can get and then assign to your organization. Service numbers can be found by using the **Skype for Business admin center**. For details, see [Getting service phone numbers](/microsoftteams/getting-service-phone-numbers).
   


### PR DESCRIPTION
Looks like settings for [Vietnam](https://docs.microsoft.com/en-us/microsoftteams/country-and-region-availability-for-audio-conferencing-and-calling-plans/availability-in-vietnam) are same as [for UAE](https://docs.microsoft.com/en-us/microsoftteams/country-and-region-availability-for-audio-conferencing-and-calling-plans/availability-in-the-united-arab-emirates-uae) but the former is not listed in the note:

> Due to limited availability of toll phone numbers in Venezuela, Indonesia, and United Arab Emirates (UAE), organizations from these countries/regions won't have an Audio Conferencing toll number automatically assigned to them. Toll-free numbers from these locations are available depending on available inventory

Therefore, I added Vietnam to the list