### PR TITLE
Troubleshooting

### DIFF
--- a/Teams/manage-resource-accounts.md
+++ b/Teams/manage-resource-accounts.md
@@ -163,6 +163,22 @@ Set-csonlinevoiceapplicationinstance -identity <Resource Account oid> -Telephone
 
 Once you do that, you can delete the resource account from the O365 admin portal, under Users tab.
 
+## Troubleshooting
+
+In case you do not see the phone number assigned to the resource account on the Teams Admin Center and you are unable to assign the number from there, please check the following:
+
+``` Powershell
+Get-MsolUser -UserPrincipalName "username@contoso.com"| fl objectID,department
+```
+
+If the department attribute displays Skype for Business Application Endpoint please run the cmdlet below :
+
+``` Powershell
+Set-MsolUser -ObjectId  -Department "Microsoft Communication Application Instance"
+```
+> [!NOTE]
+> Refresh the Teams Admin center webpage after running the cmldet, and you should be able to assign the number correctly.
+
 ## Related Information
 
 For implementations that are hybrid with Skype for Business Server:


### PR DESCRIPTION
​https://docs.microsoft.com/en-us/microsoftteams/manage-resource-accounts

Since the recent migration of services to NGC Cloud Call Queues and Cloud Auto Attendants made my MS there has been an increase of the incoming support requests, about customers being unable to assign phone numbers to resource accounts via the Teams Admin Center.

The change request, provides troubleshooting steps to resolve a recurrent issue with resource accounts migrated form Legacy Portal, that are incorrectly configured.