### PR TITLE
The hex value for 46 is incorrect

### DIFF
--- a/Teams/QoS-in-Teams.md
+++ b/Teams/QoS-in-Teams.md
@@ -178,9 +178,9 @@ Network Monitor is a tool you can [download from Microsoft](https://www.microsof
 
 3. Stop the capture.
 
-4. In the **Display Filter** field, use the source IP address of the PC that made the call, and refine the filter by defining DSCP value 46 (hex 0xb8) as search criteria, as shown in the following example:
+4. In the **Display Filter** field, use the source IP address of the PC that made the call, and refine the filter by defining DSCP value 46 (hex 0x2E) as search criteria, as shown in the following example:
 
-    Source == "192.168.137.201" AND IPv4.DifferentiatedServicesField == 0xb8
+    Source == "192.168.137.201" AND IPv4.DifferentiatedServicesField == 0x2E
 
     ![Screenshot filters in the Display Filter dialog box.](media/Qos-in-Teams-Image4.png "The Display Filter dialog box in Network Monitor, showing the filters to apply.")
 


### PR DESCRIPTION
The hex value for 46 is incorrectly documented as being 0xb8. The correct value is 2E.