### PR TITLE
Adding Maximum Limit to Message section

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -87,6 +87,7 @@ Microsoft Teams chat function works on a Microsoft Exchange backend, so you can 
 |Message size &dagger;  |25 KB   |
 |Number of file attachments &Dagger;  |10     |
 |Number of inline images &Dagger; |50   |
+|Group Chat Audio/Video/Screen Sharing person limit | 20   |
 
 &dagger; If the message exceeds this limit, a preview message is generated and the user is asked to view/download the original email from the link provided.
 


### PR DESCRIPTION
Teams Group Chat only allows 20 people to have AV at any point..

Found here: https://domoreexp.visualstudio.com/Teamspace/_git/Teamspace-Web?path=%2FWebClient%2Fsrc%2Fapp%2Fcomponents%2Fchat-header%2Fchat-header.spec.ts&version=GBdevelop