### PR TITLE
ApplicationId missing from examples

### DIFF
--- a/Skype/SfbHybrid/hybrid/configure-onprem-ra.md
+++ b/Skype/SfbHybrid/hybrid/configure-onprem-ra.md
@@ -61,8 +61,13 @@ Creating a resource account that uses a phone number would require performing th
 
 3. Create an on-premises resource account by running the `New-CsHybridApplicationEndpoint` cmdlet for each Phone System service, and give each one a name, sip address, and so on.
 
+The application ID's that you need to use while creating the resource account are:
+
+Auto Attendant: ce933385-9390-45d1-9512-c8d228074e07
+Call Queue: 11cd3e2e-fccb-42ad-ad00-878b93575e07
+
     ``` Powershell
-    New-CsHybridApplicationEndpoint -DisplayName appinstance01 -SipAddress sip:appinstance01@contoso.com -OU "ou=Redmond,dc=litwareinc,dc=com"
+    New-CsHybridApplicationEndpoint -DisplayName appinstance01 -SipAddress sip:appinstance01@contoso.com -OU "ou=Redmond,dc=litwareinc,dc=com" -ApplicationId "ce933385-9390-45d1-9512-c8d228074e07"
     ```
 
     See [New-CsHybridApplicationEndpoint](https://docs.microsoft.com/powershell/module/skype/new-cshybridapplicationendpoint?view=skype-ps) for more details on this command.
@@ -123,8 +128,15 @@ Log in to the Skype for Business front end server and run the following PowerShe
 
 1. Create an on-premises resource account by running the `New-CsHybridApplicationEndpoint` cmdlet for each Phone System service, and give each one a name, sip address, and so on.
 
+The application ID's that you need to use while creating the resource account are:
+
+Auto Attendant: ce933385-9390-45d1-9512-c8d228074e07
+Call Queue: 11cd3e2e-fccb-42ad-ad00-878b93575e07
+
+
     ``` Powershell
-    New-CsHybridApplicationEndpoint -DisplayName appinstance01 -SipAddress sip:appinstance01@litwareinc.com -OU "ou=Redmond,dc=litwareinc,dc=com"
+Auto Attendant: ce933385-9390-45d1-9512-c8d228074e07
+    New-CsHybridApplicationEndpoint -DisplayName appinstance01 -SipAddress sip:appinstance01@litwareinc.com -OU "ou=Redmond,dc=litwareinc,dc=com" -ApplicationId "ce933385-9390-45d1-9512-c8d228074e07"
     ```
 
     See [New-CsHybridApplicationEndpoint](https://docs.microsoft.com/powershell/module/skype/new-cshybridapplicationendpoint?view=skype-ps) for more details on this command.


### PR DESCRIPTION
ApplicationId is required to create Hybrid Application Endpoints (used to specify type - Call Queue or Auto Attendant).