### PR TITLE
SuppressCallerID and AlternateCallerID not used

### DIFF
--- a/Teams/direct-routing-configure.md
+++ b/Teams/direct-routing-configure.md
@@ -323,8 +323,6 @@ NumberPattern 		: ^\+1(425|206) (\d{7})$
 OnlinePstnUsages 	: {US and Canada}
 OnlinePstnGatewayList	: {sbc1.contoso.biz, sbc2.contoso.biz}
 Name		 	: Redmond 1
-SuppressCallerId	:
-AlternateCallerId	:
 </pre>
 To create the Redmond 2 route, enter:
 
@@ -480,8 +478,6 @@ The steps to create PSTN Usage "International", voice route "International," Voi
    OnlinePstnUsages          : {International} 
    OnlinePstnGatewayList           : {sbc2.contoso.biz, sbc5.contoso.biz}
    Name                            : International
-   SuppressCallerId          :
-   AlternateCallerId         :
    </pre>
 3. Next, create a Voice Routing Policy "No Restrictions". The PSTN Usage "Redmond 1" and "Redmond" are reused in this voice routing policy to preserve special handling for calls to number "+1 425 XXX XX XX" and "+1 206 XXX XX XX" as local or on-premises calls.
 


### PR DESCRIPTION
I believe SuppressCallerID and AlternateCallerID are not part of the New-CsOnlineVoiceRoute cmd-let, so should not be in example output. It is adding to confusion of users:

https://techcommunity.microsoft.com/t5/Microsoft-Teams/Direct-Routing-and-SuppressCallerId/m-p/781132