### PR TITLE
Update direct-routing-plan.md

### DIFF
--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -81,8 +81,11 @@ Firewall IP addresses and ports for Microsoft Teams media |For more information,
 Users of Direct Routing must have the following licenses assigned in Office 365: 
 
 - Microsoft Phone System 
-- Microsoft Teams 
+- Microsoft Teams + Skype for Business Plan 2 if included in Licensing Sku
 - Microsoft Audio Conferencing 
+
+> [!NOTE]
+> Skype for Business Plan should not be removed from any licensing SKU where it is included. 
 
 
 > [!IMPORTANT]


### PR DESCRIPTION
@NMuravlyannikov 

We're getting cases where customers believe they don't need SfB Plan 2 and are removing from the license assigned to users. Can we update the licensing information here to reflect that if included SfB Plan 2 must be assigned?