### PR TITLE
Update customize-the-mac-client-experience.md

### DIFF
--- a/Skype/SfbServer/deploy/deploy-clients/customize-the-mac-client-experience.md
+++ b/Skype/SfbServer/deploy/deploy-clients/customize-the-mac-client-experience.md
@@ -29,7 +29,7 @@ To set these preferences, get to a terminal prompt on the client's Mac and as ne
 
 | Key | Type | Value | Description |
 |:-----|:-----|:-----|:-----|
-|AutoDetectAutoDiscoveryURLs    |Bool    |0 = manual server configuration  <br/> 1 = automatic server detection (default)    |Specify how Skype for Business identifies the transport and server to use during sign-in. If you enable this policy setting, you must specify **internalAutoDiscoveryURL** and **externalAutoDiscoveryURL**.   |
+|autoDetectAutoDicoveryURLs    |Bool    |0 = manual server configuration  <br/> 1 = automatic server detection (default)    |Specify how Skype for Business identifies the transport and server to use during sign-in. If you enable this policy setting, you must specify **internalAutoDiscoveryURL** and **externalAutoDiscoveryURL**.   |
 |internalAutoDiscoveryURL    |String    |Full autodiscover URL    |Internal autodiscover URL    |
 |externalAutoDiscoveryURL    |String    |Full autodiscover URL    |External autodiscover URL    |
 |httpProxyDomain    |String    ||HTTP Proxy Domain    |


### PR DESCRIPTION
The `autoDetectAutoDicoveryURLs` key must contain the misspelling of "Discovery" and have the first "a" lowercase to take effect.

This old post, I believe by @bwilsonms, shows the key as it needs to be (confirmed with testing on Skype for Business 16.27.37): https://techcommunity.microsoft.com/t5/Skype-for-Business-IT-Pro/Skype-for-Business-Mac-client-Preference-Settings/m-p/66530

The change from #700 last year was a well intentioned regression.