### PR TITLE
Wording like license vs account and minor updates

### DIFF
--- a/Teams/create-an-org-wide-team.md
+++ b/Teams/create-an-org-wide-team.md
@@ -40,7 +40,7 @@ As your organization's directory is updated to include new active users or if us
 > [!NOTE]
 > - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out, you have reached the five org-wide teams limit, or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
 > - Rooms that aren't a part of a room list, equipment, and resource accounts might be added or synced to the org-wide team. Team owners can easily remove these accounts from the team.
-> - All actions by the system to add or remove members are posted in the main Teams channel. The channel will also be marked as having new activity in the Teams client.
+> - All actions by the system to add or remove members are posted in the General channel. The channel will also be marked as having new activity in the Teams client.
 
 ## Best practices
 

--- a/Teams/create-an-org-wide-team.md
+++ b/Teams/create-an-org-wide-team.md
@@ -40,7 +40,7 @@ As your organization's directory is updated to include new active users or if us
 > [!NOTE]
 > - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out, you have reached the five org-wide teams limit, or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
 > - Rooms that aren't a part of a room list, equipment, and resource accounts might be added or synced to the org-wide team. Team owners can easily remove these accounts from the team.
-> - All actions by the system to add or remove members will be posted in the Teams main channel. The channel will also be marked as having new activity in the Teams client.
+> - All actions by the system to add or remove members are posted in the main Teams channel. The channel will also be marked as having new activity in the Teams client.
 
 ## Best practices
 

--- a/Teams/create-an-org-wide-team.md
+++ b/Teams/create-an-org-wide-team.md
@@ -38,7 +38,7 @@ These types of accounts won't be added to your org-wide team:
 As your organization's directory is updated to include new active users or if users no longer work at your company and their account is disabled, changes are automatically synced and the users are added or removed from the team. Team members can't leave an org-wide team. As a team owner, you can manually add or remove users if needed.
 
 > [!NOTE]
-> - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out, you have reached the five **Org-wide** Teams limit, or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
+> - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out, you have reached the five org-wide Teams limit, or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
 > - Rooms that aren't a part of a room list, equipment, and resource accounts might be added or synced to the org-wide team. Team owners can easily remove these accounts from the team.
 > - All actions by the system to add or remove members will be posted in the Teams main channel. The channel will also be marked as having new activity in the Teams client.
 
@@ -64,7 +64,7 @@ Consider setting up channel moderation and giving moderator capabilities to cert
 
 ### Remove accounts that might not belong
 
-Even though members can’t leave an org-wide team, as a team owner, you can manage the team roster by removing accounts that don’t belong. **Make sure you use Teams to remove users from your org-wide team**. If you use another way to remove a user, such as the Microsoft 365 admin center or from a group in Outlook, the user might be added back to the org-wide team.
+Even though members can’t leave an org-wide team, as a team owner, you can manage the team roster by removing accounts that don’t belong. Make sure you use Teams to remove users from your org-wide team. If you use another way to remove a user, such as the Microsoft 365 admin center or from a group in Outlook, the user might be added back to the org-wide team.
 
 ## FAQ
 

--- a/Teams/create-an-org-wide-team.md
+++ b/Teams/create-an-org-wide-team.md
@@ -38,7 +38,7 @@ These types of accounts won't be added to your org-wide team:
 As your organization's directory is updated to include new active users or if users no longer work at your company and their account is disabled, changes are automatically synced and the users are added or removed from the team. Team members can't leave an org-wide team. As a team owner, you can manually add or remove users if needed.
 
 > [!NOTE]
-> - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out or you have reached the five **Org-wide** Teams limit or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
+> - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out, you have reached the five **Org-wide** Teams limit, or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
 > - Rooms that aren't a part of a room list, equipment, and resource accounts might be added or synced to the org-wide team. Team owners can easily remove these accounts from the team.
 > - All actions by the system to add or remove members will be posted in the Teams main channel. The channel will also be marked as having new activity in the Teams client.
 

--- a/Teams/create-an-org-wide-team.md
+++ b/Teams/create-an-org-wide-team.md
@@ -64,7 +64,7 @@ Consider setting up channel moderation and giving moderator capabilities to cert
 
 ### Remove accounts that might not belong
 
-Even though members can’t leave an org-wide team, as a team owner, you can manage the team roster by removing accounts that don’t belong. Make sure you use Teams to remove users from your org-wide team. If you use another way to remove a user, such as the Microsoft 365 admin center or from a group in Outlook, the user might be added back to the org-wide team.
+Even though members can’t leave an org-wide team, as a team owner, you can manage the team roster by removing accounts that don’t belong. **Make sure you use Teams to remove users from your org-wide team**. If you use another way to remove a user, such as the Microsoft 365 admin center or from a group in Outlook, the user might be added back to the org-wide team.
 
 ## FAQ
 

--- a/Teams/create-an-org-wide-team.md
+++ b/Teams/create-an-org-wide-team.md
@@ -35,11 +35,12 @@ These types of accounts won't be added to your org-wide team:
 - Room or equipment accounts
 - Accounts backed by a shared mailbox
 
-As your organization's directory is updated to include new active users or if users no longer work at your company and their Teams license is disabled, changes are automatically synced and the users are added or removed from the team. Team members can't leave an org-wide team. As a team owner, you can manually add or remove users if needed.
+As your organization's directory is updated to include new active users or if users no longer work at your company and their account is disabled, changes are automatically synced and the users are added or removed from the team. Team members can't leave an org-wide team. As a team owner, you can manually add or remove users if needed.
 
 > [!NOTE]
-> - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
+> - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out or you have reached the five **Org-wide** Teams limit or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
 > - Rooms that aren't a part of a room list, equipment, and resource accounts might be added or synced to the org-wide team. Team owners can easily remove these accounts from the team.
+> - All actions by the system to add or remove members will be posted in the Teams main channel. The channel will also be marked as having new activity in the Teams client.
 
 ## Best practices
 
@@ -63,7 +64,7 @@ Consider setting up channel moderation and giving moderator capabilities to cert
 
 ### Remove accounts that might not belong
 
-Even though members can’t leave an org-wide team, as a team owner, you can manage the team roster by removing accounts that don’t belong. Make sure you use Teams to remove users from your org-wide team. If you use another way to remove a user, such as the Microsoft 365 admin center or from a group in Outlook, the user might be added back to the org-wide team.
+Even though members can’t leave an org-wide team, as a team owner, you can manage the team roster by removing accounts that don’t belong. **Make sure you use Teams to remove users from your org-wide team**. If you use another way to remove a user, such as the Microsoft 365 admin center or from a group in Outlook, the user might be added back to the org-wide team.
 
 ## FAQ
 

--- a/Teams/create-an-org-wide-team.md
+++ b/Teams/create-an-org-wide-team.md
@@ -38,7 +38,7 @@ These types of accounts won't be added to your org-wide team:
 As your organization's directory is updated to include new active users or if users no longer work at your company and their account is disabled, changes are automatically synced and the users are added or removed from the team. Team members can't leave an org-wide team. As a team owner, you can manually add or remove users if needed.
 
 > [!NOTE]
-> - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out, you have reached the five org-wide Teams limit, or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
+> - If you don't see the **Org-wide** option when creating a team and you're a global admin, the feature might still be rolling out, you have reached the five org-wide teams limit, or your organization might have more than the current size limit of 5,000 members. We're looking to increase this limit in the future.
 > - Rooms that aren't a part of a room list, equipment, and resource accounts might be added or synced to the org-wide team. Team owners can easily remove these accounts from the team.
 > - All actions by the system to add or remove members will be posted in the Teams main channel. The channel will also be marked as having new activity in the Teams client.
 


### PR DESCRIPTION
* Change "disable License" to "disable account" as a license change as document won't impact the system and a license can not be disabled! But a user account can be disabled.
* Add the five org wide teams limit to the list of things that will prevent the option to show for global admins
* Added to note section the fact any change by the system will show up in the main channel and show as ne activity (bold)
* Emphasise the fact you have to remove member through the Teams UI/client, because the people often responsible are used to other tools like PowerShell, Azure Portal or Admin O365