### PR TITLE
Update to Mobile App Deployment via MDM

### DIFF
--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -119,7 +119,7 @@ Supported mobile platforms for Microsoft Teams mobile apps are the following:
 > [!NOTE]
 > The mobile version must be available to the public in order for Teams to work as expected.
 
-Mobile apps are distributed and updated through the respective mobile platform’s app store only, and are not available to be distributed through MDM (mobile device management) solutions or side-loaded.
+Mobile apps are distributed and updated through the respective mobile platform’s app store only. Distribution of the mobile apps via MDM or side-loading is not supported by Microsoft. Once the mobile app has been installed on a supported mobile platform, the mobile Apps themselves will be supported provided the version is within three months of the current release.
 
 
 | | | |

--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -119,7 +119,7 @@ Supported mobile platforms for Microsoft Teams mobile apps are the following:
 > [!NOTE]
 > The mobile version must be available to the public in order for Teams to work as expected.
 
-Mobile apps are distributed and updated through the respective mobile platform’s app store only. Distribution of the mobile apps via MDM or side-loading is not supported by Microsoft. Once the mobile app has been installed on a supported mobile platform, the mobile Apps themselves will be supported provided the version is within three months of the current release.
+Mobile apps are distributed and updated through the respective mobile platform’s app store only. Distribution of the mobile apps via MDM or side-loading is not supported by Microsoft. Once the mobile app has been installed on a supported mobile platform, the Teams Mobile App itself will be supported provided the version is within three months of the current release.
 
 
 | | | |


### PR DESCRIPTION
Clarify that the Teams App will be supported when deployed via MDM, provided it is no older than 3 months. However the actual deployment process itself is not supported by Microsoft.