### PR TITLE
Remove unnecessary text

### DIFF
--- a/Skype/SfbServer/plan-your-deployment/security/antivirus.md
+++ b/Skype/SfbServer/plan-your-deployment/security/antivirus.md
@@ -17,12 +17,6 @@ description: "Overview of antivirus scanner interoperation with Skype for Busine
 
 Overview of antivirus scanner interoperation with Skype for Business Server.
 
-This article contains recommendations that may help an administrator determine the cause of potential instability on a computer that is running a supported version of Microsoft Windows when it is used with antivirus software in an Active Directory domain environment or in a managed business environment.
-
-We recommend that you temporarily apply these procedures to evaluate a system. If your system performance or stability is improved by the recommendations that are made in this article, contact your antivirus software vendor for instructions or for an updated version of the antivirus software.
-
-This article contains information that shows how to help lower security settings or how to temporarily turn off security features on a computer. You can make these changes to understand the nature of a specific problem. Before you make these changes, we recommend that you evaluate the risks that are associated with implementing this workaround in your particular environment. If you implement this workaround, take any appropriate additional steps to help protect the computer for the files that are no longer being scanned by your antivirus software.
-
 To ensure that the antivirus scanner does not interfere with the operation of Skype for Business Server, you must exclude specific processes and directories for each Skype for Business Server server or server role on which you run an antivirus scanner. The following processes and directories should be excluded:
 
 > [!NOTE]


### PR DESCRIPTION
The article introduction includes unnecessary text, which actually works against the purpose of the article. For example, expressions such as "contains recommendations" and "temporarily apply these procedures" contravene with "you must" in the first paragraph after the removed ones. Also, the article should not "contain information that shows how to help lower security settings" and it does not show "how to temporarily turn off security features on a computer". The article includes only the list of exclusions that are required to ensure that the antivirus scanner does not interfere with the operation of Skype for Business Server. The Product Group considers them as required and expects them to be enforced before engaging on an issue. With the current introduction, it is difficult to convince the customer they are required and not optional.