### PR TITLE
Update virtual-user.md

### DIFF
--- a/Teams/teams-add-on-licensing/virtual-user.md
+++ b/Teams/teams-add-on-licensing/virtual-user.md
@@ -47,7 +47,7 @@ Contoso should consider redesigning the auto attendant and call queue system. If
 ## How to acquire Phone System–Virtual User licenses 
 
 > [!NOTE] 
-> When following these instructions, use Preview Mode to purchase a Phone System-Virtual User license.
+> When following these instructions, turn off Preview Mode to purchase a Phone System-Virtual User license.
 
 1. Sign in to the Microsoft 365 admin center.
 2. Go to **Billing** > **Purchase services** > **Add-on subscriptions**


### PR DESCRIPTION
@line 50 revised the Note to state the Preview Mode in the Admin Portal should be off.  I had a customer report issue finding the license when following the prior guidance.  I confirmed we only see the license when Preview Mode is OFF.  Not sure how we want to word this - but needs to reflect that navigating in Preview Mode of the Admin Portal doesn't show the license option so users need to turn it off if they have it on.