### PR TITLE
Update limits-specifications-teams.md

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -93,6 +93,7 @@ Channel names also can't start with an underscore (_) or period (.), or end with
 |Feature     | Maximum limit |
 |------------|---------------|
 |Number of people in a meeting  | 250    |
+|Max PowerPoint File Size | 2GB|
 
 ## Teams live events
 


### PR DESCRIPTION
Add this to Meeting Limits
|Max PowerPoint File Size | 2GB|

But please verify with PG that this is correct. We are obtaining this information from here: https://support.office.com/en-us/article/how-certain-features-behave-in-web-based-powerpoint-a931f0c8-1305-4428-8f7c-9cfa00ef28c5#OfficeVersion=PowerPoint_for_the_web

And it's our understanding that this limit applies to Teams as we use the same viewer as PPT online.