### PR TITLE
Remove System Center Operations Manager section

### DIFF
--- a/Skype/SfbServer/deploy/deploy-clients/manageability-and-tools.md
+++ b/Skype/SfbServer/deploy/deploy-clients/manageability-and-tools.md
@@ -24,9 +24,6 @@ See the following article for more details:
   
 - [Deploy SRS v1 Administrative Web Portal in Skype for Business Server](../deploy-conferencing/room-system-v1-administrative-web-portal.md)
     
-## System Center Operations Manager
-
-Skype Room System can be monitored through the System Center Operations Manager (SCOM) by downloading the [Skype Room System Management Pack](https://www.microsoft.com/download/details.aspx?id=42320) and installing it on your SCOM server. You can use SCOM to set alerts, monitor the health of Skype Room System, generate uptime reports, and much more. Skype Room System comes with a pre-installed monitoring agent that can be configured to point to SCOM server. Refer to the installation guide provided by your Skype Room System manufacturer to know how to configure the monitoring agent on Skype Room System.
   
 ## Exchange Checklist
 


### PR DESCRIPTION
119090324002196 - This section is not applicable and must be removed. The link points back to the old Lync Room System management pack and the LRS management pack is not designed for use to monitor Skype Room System. There exists no SRS management pack for SCOM as the Skype/SCOM program groups (terrya from Skype and negarg from SCOM ) have confirmed the supportability of the product going forward is monitoring for SRS by using OMS/Log Analytics/Azure Monitoring