### PR TITLE
Updating the App Locker white listing rule

### DIFF
--- a/Teams/applocker-in-teams.md
+++ b/Teams/applocker-in-teams.md
@@ -33,11 +33,12 @@ Since Teams desktop executable files are digitally signed, the publisher conditi
 
 ### Example of publisher condition rules
 
-For the Teams client app (all files, all versions):
+For the Teams client app (all files, all versions) add the following to the Executable Rules & DLL Rules:
 
 ```
 Publisher: O=MICROSOFT CORPORATION, L=REDMOND, S=WASHINGTON, C=US
 Product name: MICROSOFT TEAMS
+Product name: MICROSOFT TEAMS UPDATE
 ```
 
 ## Related topics


### PR DESCRIPTION
Adding more details to enable Teams app white listed with App Locker.