### PR TITLE
New route on network-planner.md

### DIFF
--- a/Teams/network-planner.md
+++ b/Teams/network-planner.md
@@ -22,7 +22,7 @@ appliesto:
 
 # Use the Network Planner for Microsoft Teams
 
-Network Planner is a new tool that is available in the Teams admin center. It can be found by going to **Org-wide settings** > **Network planner**. In just a few steps, the Network Planner can help you determine and organize network requirements for connecting Microsoft Teams users across your organization. When you provide your network details and Teams usage, the Network Planner calculates your network requirements for deploying Teams and cloud voice across your organization’s physical locations.
+Network Planner is a new tool that is available in the Teams admin center. It can be found by going to **Planning** > **Network planner**. In just a few steps, the Network Planner can help you determine and organize network requirements for connecting Microsoft Teams users across your organization. When you provide your network details and Teams usage, the Network Planner calculates your network requirements for deploying Teams and cloud voice across your organization’s physical locations.
 
 ![Screenshot of Network Planner](media/network-planner.png)
 


### PR DESCRIPTION
On Teams admin portal, the route of configure Network planner is changed to Planning>Network planner

- [x] Content fix