### PR TITLE
Note on measuring network performance through ICMP

### DIFF
--- a/Skype/SfbOnline/optimizing-your-network/media-quality-and-network-connectivity-performance.md
+++ b/Skype/SfbOnline/optimizing-your-network/media-quality-and-network-connectivity-performance.md
@@ -165,6 +165,9 @@ The following are the network performance targets or thresholds that are require
 <a name="bkNetworkPerf"> </a>
 
 To measure the actual network performance, especially for latency and packet loss, from any company network site to a network Edge, you can use tools such as ping, test against a set of Skype for Business media relay services running from the Microsoft Edge and data center sites. 
+
+>[!NOTE]
+> Measuring network performance through ping (ICMP) is not effective. For that reason, the anycast IP expose below will stop answering to ICMP requests starting in Jan, 2020. To measure network performace effectively, Microsoft recommends the [Network Assesment Tool](https://www.microsoft.com/en-us/download/details.aspx?id=53885).
   
 For testing Internet connections to the Microsoft network, it is recommended that you test against the following VIPs of the Skype for Business media relays. The *Anycast VIP*  will resolve to an IP address of a Media Relay in a Microsoft network Edge site that is closest to the testing location.
   


### PR DESCRIPTION
PG is discontinuing ICMP requests to 13.107.8.2 as that is not an effective way of measuring it. Some customers have been unable to use it already, and this is creating some Service Requests to CSS. I've added a note.
See https://icm.ad.msft.net/imp/v3/incidents/details/157254636/home for more info from Mykhailo Moroz.