### PR TITLE
Update direct-routing-migrating.md

### DIFF
--- a/Teams/direct-routing-migrating.md
+++ b/Teams/direct-routing-migrating.md
@@ -84,6 +84,8 @@ It is recommended that you remove previously configured voice routing informatio
 ```
 Grant-CsVoiceRoutingPolicy -PolicyName $NULL -Identity <UPN> 
 ```
+> If a global CsVoiceRoutingPolicy is configured, it is recommended that you remove any PSTN usages associated with this global policy. 
+
 ## Migrating from Office 365 Phone System with on-premises PSTN connectivity via Cloud Connector Edition 
 
 For more information about migrating from Phone System with on-premises PSTN connectivity via Cloud Connector, see the following:


### PR DESCRIPTION
@NMuravlyannikov , @CarolynRowe 
For Migrating from OPCH and CCE sections, not sure how the links to setting up OPCH and CCE provide information about migrating from these solutions because I didn't see any such information about migrating from these solutions in the referenced docs. 

Also for the recommendation to remove the CsVoiceRoutingPolicy assignment, we are showing a user level assignment which may or may not be effective depending on if a global voice routing policy is in place. Should we add a note regarding this recommending removing the global policy as well.