### PR TITLE
Changed description on Override caller ID Policy

### DIFF
--- a/Teams/caller-id-policies.md
+++ b/Teams/caller-id-policies.md
@@ -39,7 +39,7 @@ You can edit the global policy or create and assign a custom policy. If a user i
 4. From here, choose the settings that you want:
 
     - **Block incoming caller ID**: Turn on this setting to block the caller ID of incoming calls from being displayed.
-    - **Users can override the caller ID policy**: Turn on this setting to let users override the settings in the policy. This means that users can choose whether to display their caller ID or block the caller ID of an incoming call.
+    - **Users can override the caller ID policy**: Turn on this setting to let users override the settings in the policy regarding displaying their number to callees or not. This means that users can choose whether to display their caller ID.
     - **Replace caller ID**: Set the caller ID to be displayed for users by selecting one of the following:
 
         - **User's number**: Displays the user's number. 


### PR DESCRIPTION
The subtract I've changed of the text was confusing, as enabling "Override Caller ID Policy" will allow only the user to choose if he wants to call showing his number or as anonymous. It won't allow the user to change if he wants to see the number of the caller or not.