### PR TITLE
Update to support Surface Hub meetings in GCC

### DIFF
--- a/Teams/plan-for-government-gcc.md
+++ b/Teams/plan-for-government-gcc.md
@@ -95,7 +95,7 @@ To accommodate the requirements of our government cloud customers, there are som
 | | Meeting notes | Available |
 | | Live Events | Available |
 | | Federated meetings | Available |
-| | Surface Hub support | Not available |
+| | Surface Hub support | Available |
 | Calls | Contacts | Available |
 | | History | Available |
 | | Voicemail | Available |


### PR DESCRIPTION
As of November 1, Surface Hub was moved to a supported state for GCC tenants.