### PR TITLE
ALLUSERS=1 be added as a default property

### DIFF
--- a/Teams/msi-deployment.md
+++ b/Teams/msi-deployment.md
@@ -88,11 +88,11 @@ Default behavior of the MSI is to install the Teams client as soon as a user sig
 
 For the 32-bit version
 ```
-msiexec /i Teams_windows.msi OPTIONS="noAutoStart=true"
+msiexec /i Teams_windows.msi OPTIONS="noAutoStart=true" ALLUSERS=1
 ```
 For the 64-bit version
 ```
-msiexec /i Teams_windows_x64.msi OPTIONS="noAutoStart=true"
+msiexec /i Teams_windows_x64.msi OPTIONS="noAutoStart=true" ALLUSERS=1
 ```
 
 > [!Note]


### PR DESCRIPTION
ALLUSERS=1 be added as a default property, or:
The articles (https://docs.microsoft.com/en-us/microsoftteams/msi-deployment and https://docs.microsoft.com/en-us/microsoftteams/teams-for-vdi) be updated to clearly indicate that ALLUSERS=1 is always required, and ALSO clearly articulate the difference between ALLUSER=1 and ALLUSERS=1 in (https://docs.microsoft.com/en-us/microsoftteams/teams-for-vdi) as experienced packagers might just see ALLUSER=1 as a typo, and think ALLUSERS=1 is required for non-persistent VDI installs only, which is clearly incorrect.