### PR TITLE
OS upgrade not supported update

### DIFF
--- a/Lync/LyncServer/lync-server-2013-system-requirements-for-servers-running-lync-server-2013.md
+++ b/Lync/LyncServer/lync-server-2013-system-requirements-for-servers-running-lync-server-2013.md
@@ -68,6 +68,8 @@ Standard Edition and Enterprise Edition server can use any of the following:
 
 Install the operating system software on the Standard Edition Server or Enterprise Edition Front End Server. Apply all updates in order to bring the operating system up to the latest update and required update level consistent with your organization’s standards. For more details about the operating requirements, see [Server and tools operating system support in Lync Server 2013](lync-server-2013-server-and-tools-operating-system-support.md) in the Supportability documentation.
 
+Note:  In-place upgrade of the OS is not supported with Lync Server 2013.  You must deploy a separate pool and migrate users to the new pool with a difference OS.
+
 <div>
 
 

--- a/Lync/LyncServer/lync-server-2013-system-requirements-for-servers-running-lync-server-2013.md
+++ b/Lync/LyncServer/lync-server-2013-system-requirements-for-servers-running-lync-server-2013.md
@@ -68,7 +68,7 @@ Standard Edition and Enterprise Edition server can use any of the following:
 
 Install the operating system software on the Standard Edition Server or Enterprise Edition Front End Server. Apply all updates in order to bring the operating system up to the latest update and required update level consistent with your organization’s standards. For more details about the operating requirements, see [Server and tools operating system support in Lync Server 2013](lync-server-2013-server-and-tools-operating-system-support.md) in the Supportability documentation.
 
-Note:  In-place upgrade of the OS is not supported with Lync Server 2013.  You must deploy a separate pool and migrate users to the new pool with a difference OS.
+> [!NOTE] In-place upgrade of the operating system is not supported with Lync Server 2013.  You must deploy a separate pool and migrate users to the new pool with a different operating system.
 
 <div>
 


### PR DESCRIPTION
Added in information that OS upgrade isn't supported as per https://techcommunity.microsoft.com/t5/skype-for-business-blog/lync-and-skype-for-business-server-base-os-upgrade/ba-p/1092434