### PR TITLE
Update create-a-phone-system-call-queue.md

### DIFF
--- a/Teams/create-a-phone-system-call-queue.md
+++ b/Teams/create-a-phone-system-call-queue.md
@@ -197,9 +197,9 @@ Call agents selected must be:
 **Routing method** You can choose either **Attendant**, **Serial**, or **Round Robin** as the distribution method. All new and existing call queues have attendant routing selected by default. When attendant routing is used, the first call in the queue rings all call agents at the same time. The first call agent to pick up the call gets the call.
 
 - **Attendant routing** causes the first call in the queue to ring all call agents at the same time. The first call agent to pick up the call gets the call.
-- **Serial routing** incoming calls ring call agents one by one, from the beginning of the call agent list. Agents can't be ordered within the call agent list. If an agent dismisses or does not pick up a call, the call will ring the next agent and will try all agents until it is picked up or times out.
+- **Serial routing** incoming calls ring all call agents one by one, from the beginning of the call agent list. Agents can't be ordered within the call agent list. If an agent dismisses or does not pick up a call, the call will ring the next agent and will try all agents until it is picked up or times out.
   > [!NOTE]
-  > Serial routing will skip agents who are **Offline**, have set their presence to **Do not Disturb**, or have **opted out** of getting calls from this queue.
+  > With Serial routing, for agents who are **Offline** or have set their presence to **Do not Disturb**, the call will be routed to those users and fail to connect unavailable user, the routing to the next agent in the agent list. This is not the case if the agent has **opted out** of getting calls from the call queue. To reduce the time interval the call routes to next agent in line, Agent Alert time can be decreased.
 - **Round robin** balances routing of incoming calls so that each call agent gets the same number of calls from the queue. This may be desirable in an inbound sales environment to assure equal opportunity among all the call agents.
 
 ### Select an agent opt-out option


### PR DESCRIPTION
Proposing change since the tested behaviour verified is that even if the agent is offline or set to do not disturb, although the call does not notify the user, it is still routed to that user and fail to connect since the user is unavailable. There have been support requests about this matter. For the moment the call routing for call queues is not presence based. This can be the case in the future but there is no ETA for that to happen at this moment.