### PR TITLE
Update app-permissions.md

### DIFF
--- a/Teams/app-permissions.md
+++ b/Teams/app-permissions.md
@@ -164,7 +164,7 @@ REPLYTO_CONNECTOR_MESSAGE. Certain connectors support actionable messages, which
 
 ## Outgoing webhooks
 
-*Outgoing webhooks* are created on the fly by team owners or team members if sideloading is enabled for a tenant. They aren't capabilities of Teams apps; this information is included for completeness.
+*Outgoing webhooks* are created on the fly by team owners or team members. They aren't capabilities of Teams apps; this information is included for completeness.
 
 ### Required permissions
 


### PR DESCRIPTION
Sideloading does not control Outgoing webhooks. Confirmed to be a bug and by design this should not block:

https://domoreexp.visualstudio.com/DefaultCollection/MSTeams/_workitems/edit/645184
https://domoreexp.visualstudio.com/DefaultCollection/MSTeams/_workitems/edit/366311
https://domoreexp.visualstudio.com/DefaultCollection/MSTeams/_workitems/edit/643796