### PR TITLE
update sign-in-teams.md

### DIFF
--- a/Teams/sign-in-teams.md
+++ b/Teams/sign-in-teams.md
@@ -34,7 +34,13 @@ Modern authentication is a process that lets Teams know that users have already 
 
 - If users are signed in to a domain-joined computer, when they start Teams, they might be asked to go through one more authentication step, depending on whether your organization opted to require MFA or if their computer already requires MFA to sign in. If their computer already requires MFA to sign in, when they open up Teams, the app automatically starts.
 
-- If users are signed in to a domain-joined computer and their admin has enabled the policy to ignore local username, they will now be able to sign in to Teams without the username pre-filled on the Welcome screen.
+- If users are signed in to a domain-joined computer and you don't want their user name pre-populated on the Teams sign-in screen, admins can set the following Windows registry to turn off pre-population of the user name:
+  Computer\HKEY_CURRENT_USER\Software\Microsoft\Office\Teams
+  DisableUpnSuffixCheck(REG_DWORD)
+  0x00000001 (1)
+
+  Note: Skipping user name pre-fill for user names that end in ".local" or ".corp" is on by default, so you don't need to set a registry key to turn these off. 
+
 
 ### Mac users 
 

--- a/Teams/sign-in-teams.md
+++ b/Teams/sign-in-teams.md
@@ -34,6 +34,8 @@ Modern authentication is a process that lets Teams know that users have already 
 
 - If users are signed in to a domain-joined computer, when they start Teams, they might be asked to go through one more authentication step, depending on whether your organization opted to require MFA or if their computer already requires MFA to sign in. If their computer already requires MFA to sign in, when they open up Teams, the app automatically starts.
 
+- If users are signed in to a domain-joined computer and their admin has enabled the policy to ignore local username, they will now be able to sign in to Teams without the username pre-filled on the Welcome screen.
+
 ### Mac users 
 
 When users start Teams, their computer won't be able to pull their credentials from their Office 365 Enterprise account or any of their other Office applications. Instead, they'll see a prompt asking them for SFA or MFA (depending on your organization's settings). Once users enter their credentials, they won't be required to provide them again. From that point on, Teams automatically starts whenever they're working on the same computer.


### PR DESCRIPTION
We are improving the sign in experience to Microsoft Teams. Here is a quick overview of the changes:
•	Users that have a cloud username that is different from their on-prem username can now sign into Teams without the username pre-filled on Welcome screen

IT admins need to set up a registry key that will ignore the on-prem username and not prefill it on the Welcome screen at the time of sign in. However, if the on-prem username ends in .local or .corp, admins do not need to take any explicit action to suppress the prefill.