### PR TITLE
Update direct-routing-plan-media-bypass.md

### DIFF
--- a/Teams/direct-routing-plan-media-bypass.md
+++ b/Teams/direct-routing-plan-media-bypass.md
@@ -313,28 +313,28 @@ The port range of the Media Processors (applicable to all environments) is shown
 UDP/SRTP | Media Processor | SBC | 49 152 – 53 247    | Defined on the SBC |
 | UDP/SRTP | SBC | Media Processor | Defined on the SBC | 49 152 – 53 247     |
 
-## Considerations if you have Skype for Business phones in your network  
+## Configure separate trunks for Media Bypass and non Media Bypass  
 
-If you have any Skype for Business end points in your network that are using Direct Routing--for example, a Teams user can have a 3PIP phone that is based on Skype for Business client--the media bypass on the trunk that serves these users must be turned off.
-
-You can create a separate trunk for these users and assign it an Online Voice Routing policy.
+If you are migrating to Media Bypass from non Media Bypass and want to confirm functionality before migrating all usage to Media Bypass, you can create a separate trunk and separate Online Voice Routing Policy to route to the Media Bypass trunk and assign to specific users. 
 
 High-level configuration steps:
 
-- Split users by type – depending on whether the user has a 3PIP phone or not.
+- Identity users to test Media Bypass
 
 - Create two separate trunks with different FQDNs: one enabled for media bypass; the other not. 
 
   Both trunks point to the same SBC. The ports for TLS SIP signaling must be different. The ports for media must be the same.
 
-- Assign the correct trunk depending on the type of the user in the Online Voice Routing policy.
+- Create new Online Voice Routing Policy and assign media bypass trunk to the corresponding routes associated with the PSTN usage for this policy.
+
+- Assign the new Online Voice Routing Policy to users you have identified to test Media Bypass 
 
 The example below illustrates this logic.
 
 | Set of users | Number of users | Trunk FQDN assigned in OVRP | Media bypass enabled |
 | :------------ |:----------------- |:--------------|:--------------|
-Users with Teams clients and 3PIP phones | 20 | sbc1.contoso.com:5061 | false | 
-Users with only Teams end points (including new phones certified for Teams) | 980 | sbc2.contoso.com:5060 | true
+Users with non media bypass trunk | 980 | sbc1.contoso.com:5060 | true
+Users with media bypass trunk | 20 | sbc2.contoso.com:5061 | false | 
 
 Both trunks can point to the same SBC with the same public IP address. The TLS signaling ports on the SBC must be different, as shown in the following diagram. Note you will need to make sure that your certificate supports both trunks. In SAN, you need to have two names (**sbc1.contoso.com** and **sbc2.contoso.com**) or have a wildcard certificate.
 
@@ -350,9 +350,9 @@ For information about how to configure two trunks on the same SBC, see the docum
 
 ## Client endpoints supported with media bypass
 
-Media bypass is supported with all Teams endpoints.
+Media bypass is supported with all Teams Desktop clients and Teams Phone Devices. 
 
-Note for web clients (Teams Web app in Microsoft Edge, Google Chrome or Mozilla Firefox) we will covert the call to non-bypass even if it started as a bypass call. This happens automatically and does not require any actions from the administrator. 
+For all other endpoints that do not support media bypass, we will covert the call to non-bypass even if it started as a bypass call. This happens automatically and does not require any actions from the administrator. This includes Skype for Business 3PIP Phones, and Teams Web Clients that support Direct Routing calling (New Microsoft Edge based on Chromium, Google Chrome, Mozilla Firefox). 
  
 ## See also
 


### PR DESCRIPTION
@NMuravlyannikov @CarolynRowe 
Updating this document to reflect changes in service where we automatically change media bypass call to non media bypass call for all endpoints that don't support including 3PIP phones. I adjusted the 3PIP phone section to be about migrating to media bypass since this is still useful information. I modified the drawing and need to figure out how to upload it to replace the existing direct-routing-media-bypass-7.png.