### PR TITLE
Removed OPUS from codecs list

### DIFF
--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -307,7 +307,7 @@ Applies to both media bypass case and non-bypass cases.
 The Direct Routing interface on the leg between the Session Border Controller and Cloud Media Processor (without media bypass) or between the Teams client and the SBC (if Media Bypass enabled) can use the following codecs:
 
 - Non-Media bypass (SBC to Cloud Media Processor): SILK, G.711, G.722, G.729
-- Media Bypass (SBC to Teams client):  SILK, G.711, G.722, G.729, OPUS
+- Media Bypass (SBC to Teams client):  SILK, G.711, G.722, G.729
 
 You can force use of the specific codec on the Session Border Controller by excluding undesirable codecs from the offer.
 


### PR DESCRIPTION
OPUS is officially not supported by Teams, removed it from the list in spec