### PR TITLE
Update assignments-in-teams.md : remove preview tag from shipped features

### DIFF
--- a/Teams/expand-teams-across-your-org/assignments-in-teams.md
+++ b/Teams/expand-teams-across-your-org/assignments-in-teams.md
@@ -35,7 +35,6 @@ With the admin settings in Microsoft Teams admin center you can turn the followi
 
 <a name="#bkemaildigest"> </a>
 ### Weekly guardian email digest
-[!INCLUDE [preview-feature](../includes/preview-feature.md)]
 
 Guardian emails are weekly emails sent to students' parents or guardians. The emails will contain information about assignments from the previous week and for the upcoming week, and will be sent over the weekend. The emails need to be updated by the admins using the School Data Sync feature.
 
@@ -53,7 +52,6 @@ This setting is off by default.
 
 <a name="#turnitin"> </a>
 ### Turnitin
-[!INCLUDE [preview-feature](../includes/preview-feature.md)]
 
 Turnitin is a plagiarism detection service. This is a third party product or service that is subject to its own terms and privacy policy. You are responsible for your use of any third party products and services.
 


### PR DESCRIPTION
Remove "preview" tag from documentation of features that have shipped.

In product we have already removed the Beta/preview text:
![image](https://user-images.githubusercontent.com/6433784/75478844-7814ad00-5953-11ea-948f-3a08c934b1c8.png)

The documentation needed to be updated too