### PR TITLE
Added back in language for chat with tag

### DIFF
--- a/Teams/manage-tags.md
+++ b/Teams/manage-tags.md
@@ -30,7 +30,7 @@ Tags in Microsoft Teams let users communicate with a subset of people on a team.
 
 ## How tags work
 
-A tag can be added to a person on a specific team. After a tag is added, it can be used in @mentions in any standard channel of the team or used to start a chat with the tag members. Here's some examples of how tags can be used in Teams:
+A tag can be added to a person on a specific team. The tags can then be used in @mentions by anyone on the team in a channel post or to start a conversation with only those people who are assigned that tag. Here's some examples of how tags can be used in Teams:
 
 - A store manager wants to post an announcement to a channel and notify all cashiers.
 - A group product manager wants to message all product managers in a channel.

--- a/Teams/manage-tags.md
+++ b/Teams/manage-tags.md
@@ -23,18 +23,19 @@ description: Learn to manage how tags are used in your organization in Microsoft
 > [!NOTE]
 > Don't see this feature in the Microsoft Teams admin center yet? It's currently being rolled out and might not be available in your organization yet. To stay on top of upcoming Teams features, check out the [Microsoft 365 Roadmap](https://www.microsoft.com/microsoft-365/roadmap?filters=&searchterms=microsoft%2Cteams).
 
-Tags in Microsoft Teams let users communicate with a subset of people on a team. Tags can be added to one or multiple team members to easily connect with the right subset of people. Team owners and members (if the feature is enabled for them) can add one or more tags to a person. The tags can then be used in @mentions by anyone on the team in a channel post to communicate with only those people who are assigned that tag.
+Tags in Microsoft Teams let users communicate with a subset of people on a team. Tags can be added to one or multiple team members to easily connect with the right subset of people. Team owners and members (if the feature is enabled for them) can add one or more tags to a person. The tags can then be used to start a chat or in a channel post by anyone on the team to communicate with those people who are assigned that tag.
 
 > [!NOTE]
 > Tags are not yet supported in private channels.
 
 ## How tags work
 
-A tag can be added to a person on a specific team. After a tag is added, it can be used in @mentions in any standard channel of the team. Here's some examples of how tags can be used in Teams:
+A tag can be added to a person on a specific team. After a tag is added, it can be used in @mentions in any standard channel of the team or used to start a chat with the tag members. Here's some examples of how tags can be used in Teams:
 
 - A store manager wants to post an announcement to a channel and notify all cashiers.
 - A group product manager wants to message all product managers in a channel.
 - A hospital administrator wants to send a message to all radiologists in a channel.
+- A marketing manager wants to start a group chat with all designers. 
 
 To learn more, check out [Using tags in Teams](https://support.office.com/article/using-tags-in-teams-667bd56f-32b8-4118-9a0b-56807c96d91e).
 

--- a/Teams/manage-tags.md
+++ b/Teams/manage-tags.md
@@ -23,14 +23,14 @@ description: Learn to manage how tags are used in your organization in Microsoft
 > [!NOTE]
 > Don't see this feature in the Microsoft Teams admin center yet? It's currently being rolled out and might not be available in your organization yet. To stay on top of upcoming Teams features, check out the [Microsoft 365 Roadmap](https://www.microsoft.com/microsoft-365/roadmap?filters=&searchterms=microsoft%2Cteams).
 
-Tags in Microsoft Teams let users communicate with a subset of people on a team. Tags can be added to one or multiple team members to easily connect with the right subset of people. Team owners and members (if the feature is enabled for them) can add one or more tags to a person. The tags can then be used to start a chat or in a channel post by anyone on the team to communicate with those people who are assigned that tag.
+Tags in Microsoft Teams let users communicate with a subset of people on a team. Tags can be added to one or multiple team members to easily connect with the right subset of people. Team owners and members (if the feature is enabled for them) can add one or more tags to a person. The tags can then be used in @mentions by anyone on the team in a channel post or to start a conversation with only those people who are assigned that tag.
 
 > [!NOTE]
 > Tags are not yet supported in private channels.
 
 ## How tags work
 
-A tag can be added to a person on a specific team. The tags can then be used in @mentions by anyone on the team in a channel post or to start a conversation with only those people who are assigned that tag. Here's some examples of how tags can be used in Teams:
+A tag can be added to a person on a specific team. After a tag is added, it can be used in @mentions in a chat or in any standard channel of the team. Here's some examples of how tags can be used in Teams:
 
 - A store manager wants to post an announcement to a channel and notify all cashiers.
 - A group product manager wants to message all product managers in a channel.


### PR DESCRIPTION
changed 
* The tags can then be used to start a chat or in a channel post by anyone on the team to communicate with those people who are assigned that tag.
* After a tag is added, it can be used in @mentions in any standard channel of the team or used to start a chat with the tag members.

Added
* - A marketing manager wants to start a group chat with all designers.