### PR TITLE
Update Step 2.a. with correct URI

### DIFF
--- a/Skype/SfbServer/deploy/deploy-enterprise-voice/deploy-shared-line-appearance.md
+++ b/Skype/SfbServer/deploy/deploy-enterprise-voice/deploy-shared-line-appearance.md
@@ -36,7 +36,7 @@ Shared Line Appearance (SLA) is a new feature in Skype for Business Server, Nove
     a. Register SLA as a server application by running the following command for each pool:
 
    ```powershell
-   New-CsServerApplication -Identity 'Service:Registrar:%FQDN%/SharedLineAppearance' -Uri 	https://www.microsoft.com/LCS/SharedLineAppearance -Critical $false -Enabled 				$true -Priority (Get-CsServerApplication -Identity 				'Service:Registrar:%FQDN%/UserServices').Priority
+   New-CsServerApplication -Identity 'Service:Registrar:%FQDN%/SharedLineAppearance' -Uri 	http://www.microsoft.com/LCS/SharedLineAppearance -Critical $false -Enabled $true -Priority (Get-CsServerApplication -Identity  'Service:Registrar:%FQDN%/UserServices').Priority
    ```
 
    where %FQDN% is the fully qualified domain name of the pool.


### PR DESCRIPTION
In Step 2.a., the -Uri example is https:// rather than http:// which is incorrect and will cause failures.