### PR TITLE
OP note re: notifications on delegate answer

### DIFF
--- a/Teams/set-up-phone-system-voicemail.md
+++ b/Teams/set-up-phone-system-voicemail.md
@@ -56,7 +56,8 @@ The following information is about configuring Cloud Voicemail to work with on-p
 
 6. To enable Voicemail features such as customizing greetings, and visual voicemail in Skype for Business clients, connectivity from Office 365 to the Exchange server mailbox via Exchange Web Services is required. To enable this connectivity you must configure the new Exchange Oauth authentication protocol described in [Configure OAuth authentication between Exchange and Exchange Online organizations](https://technet.microsoft.com/library/dn594521(v=exchg.150).aspx), or run the Exchange Hybrid Wizard from Exchange 2013 CU5 or greater. Additionally, you must configure integration and Oauth between Skype for Business Online and Exchange server described in [Configure Integration and OAuth between Skype for Business Online and Exchange Server](https://docs.microsoft.com/skypeforbusiness/deploy/integrate-with-exchange-server/oauth-with-online-and-on-premises). 
 
-Note:  Notifications when a delegate answers a call on behalf of a delegator is not available in Cloud Voicemail.  Users can receive notifications for missed calls.
+> [!NOTE]
+> When a delegate answers a call on behalf of a delegator, notifications are not available in Cloud Voicemail. Users can receive notifications for missed calls.
 
 ## Setting voicemail policies in your organization
 
@@ -129,5 +130,4 @@ We have training information and articles to help your users be successful with 
 [Here's what you get with Phone System in Office 365](here-s-what-you-get-with-phone-system.md)
 
 [Plan for Skype for Business Server and Exchange Server migration](https://docs.microsoft.com/SkypeForBusiness/hybrid/plan-um-migration)
-
 

--- a/Teams/set-up-phone-system-voicemail.md
+++ b/Teams/set-up-phone-system-voicemail.md
@@ -56,6 +56,8 @@ The following information is about configuring Cloud Voicemail to work with on-p
 
 6. To enable Voicemail features such as customizing greetings, and visual voicemail in Skype for Business clients, connectivity from Office 365 to the Exchange server mailbox via Exchange Web Services is required. To enable this connectivity you must configure the new Exchange Oauth authentication protocol described in [Configure OAuth authentication between Exchange and Exchange Online organizations](https://technet.microsoft.com/library/dn594521(v=exchg.150).aspx), or run the Exchange Hybrid Wizard from Exchange 2013 CU5 or greater. Additionally, you must configure integration and Oauth between Skype for Business Online and Exchange server described in [Configure Integration and OAuth between Skype for Business Online and Exchange Server](https://docs.microsoft.com/skypeforbusiness/deploy/integrate-with-exchange-server/oauth-with-online-and-on-premises). 
 
+Note:  Notifications when a delegate answers a call on behalf of a delegator is not available in Cloud Voicemail.  Users can receive notifications for missed calls.
+
 ## Setting voicemail policies in your organization
 
 > [!WARNING]


### PR DESCRIPTION
Added note (formatting may be required) that notifications for when a delegate answers a call on behalf of a delegator.

Note:  Notifications when a delegate answers a call on behalf of a delegator is not available in Cloud Voicemail.  Users can receive notifications for missed calls.