### PR TITLE
Removed port 5062 for GCCH, not applicable.

### DIFF
--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -253,7 +253,7 @@ You must use the following ports for Office 365 environments where Direct Routin
 
 |**Traffic**|**From**|**To**|**Source port**|**Destination port**|
 |:--- |:--- |:--- |:--- |:--- |
-|SIP/TLS|SIP Proxy|SBC|1024 – 65535|Defined on the SBC (For Office 365 GCC High/DoD only ports 5061 and 5062 must be used)|
+|SIP/TLS|SIP Proxy|SBC|1024 – 65535|Defined on the SBC (For Office 365 GCC High/DoD only port 5061 must be used)|
 SIP/TLS|SBC|SIP Proxy|Defined on the SBC|5061|
 ||||||
 


### PR DESCRIPTION
Removed port 5062 for GCCH, not applicable.