### PR TITLE
Removed note about Content camera support for Surface Pro-based system

### DIFF
--- a/Teams/rooms/content-camera.md
+++ b/Teams/rooms/content-camera.md
@@ -96,6 +96,4 @@ You can also adjust these settings remotely using an [XML configuration file](xm
 
 [Microsoft Teams Rooms requirements](requirements.md)
 
-> [!NOTE]
-> Certain Microsoft Teams Room devices that have Microsoft Surface Pro based consoles (such as, Logitech Smartdock and Crestron SR) do not yet support content camera. Support for these devices will added later in CY2019. 
->
+


### PR DESCRIPTION
Content camera support for Surface Pro-based system (Minimum required app build: 4.2.4.0)