### PR TITLE
Update use-call-analytics-to-troubleshoot-poor-call-quality.md

### DIFF
--- a/Teams/use-call-analytics-to-troubleshoot-poor-call-quality.md
+++ b/Teams/use-call-analytics-to-troubleshoot-poor-call-quality.md
@@ -63,7 +63,7 @@ See your Teams and Skype for Business admin if you need help with permissions.
   
 4. Select the user from the list.
 
-5. Select **Call history**, and then select the call or meeting that you want to troubleshoot.
+5. Select **Call history**, and then select the call or meeting that you want to troubleshoot.  A maximum of 500 records will be returned.
     
     ![Screenshot of the call history page for a user.](media/use-call-analytics-to-troubleshoot-image-2.png)
   


### PR DESCRIPTION
Documenting the limitation that 500 records will be returned for the Call analytics query on an end-user.