### PR TITLE
Update Exchange-Teams-interact.md

### DIFF
--- a/Teams/Exchange-Teams-interact.md
+++ b/Teams/Exchange-Teams-interact.md
@@ -74,6 +74,9 @@ Microsoft Teams works with several Office 365 services to provide users with a r
 - To let Microsoft Teams work with Exchange on-premises, you must configure the new Exchange OAuth authentication protocol as described in [Configure OAuth authentication between Exchange and Exchange Online organizations](https://docs.microsoft.com/exchange/configure-oauth-authentication-between-exchange-and-exchange-online-organizations-exchange-2013-help).
 
 > [!NOTE]
+>The Outlook Teams add-in can be used to Schedule a Teams meeting for mailboxes hosted in Exchange on-premises. However, scheduling a Teams meeting on behalf of another user with Exchange on-premises requires Exchange 2013 CU9 and above and the new Exchange OAuth authentication protocol. Both delegate and delegator must have mailbox on Exchange on-premises.
+
+> [!NOTE]
 >For Exchange On-Premises and Teams integration, the required license needs to be assigned for the AAD synced user.
 
 > [!IMPORTANT]

--- a/Teams/Exchange-Teams-interact.md
+++ b/Teams/Exchange-Teams-interact.md
@@ -74,7 +74,7 @@ Microsoft Teams works with several Office 365 services to provide users with a r
 - To let Microsoft Teams work with Exchange on-premises, you must configure the new Exchange OAuth authentication protocol as described in [Configure OAuth authentication between Exchange and Exchange Online organizations](https://docs.microsoft.com/exchange/configure-oauth-authentication-between-exchange-and-exchange-online-organizations-exchange-2013-help).
 
 > [!NOTE]
->The Outlook Teams add-in can be used to Schedule a Teams meeting for mailboxes hosted in Exchange on-premises. However, scheduling a Teams meeting on behalf of another user with Exchange on-premises requires Exchange 2013 CU9 and above and the new Exchange OAuth authentication protocol. Both delegate and delegator must have mailbox on Exchange on-premises.
+> The Outlook Teams add-in can be used to schedule a Teams meeting for mailboxes hosted in Exchange on-premises. However, scheduling a Teams meeting on behalf of another user with Exchange on-premises requires Exchange 2013 CU9 and above and the new Exchange OAuth authentication protocol. Both delegate and delegator must have a mailbox on Exchange on-premises.
 
 > [!NOTE]
 >For Exchange On-Premises and Teams integration, the required license needs to be assigned for the AAD synced user.

--- a/Teams/Exchange-Teams-interact.md
+++ b/Teams/Exchange-Teams-interact.md
@@ -77,7 +77,7 @@ Microsoft Teams works with several Office 365 services to provide users with a r
 > The Outlook Teams add-in can be used to schedule a Teams meeting for mailboxes hosted in Exchange on-premises. However, scheduling a Teams meeting on behalf of another user with Exchange on-premises requires Exchange 2013 CU9 and above and the new Exchange OAuth authentication protocol. Both delegate and delegator must have a mailbox on Exchange on-premises.
 
 > [!NOTE]
->For Exchange On-Premises and Teams integration, the required license needs to be assigned for the AAD synced user.
+> For Exchange On-Premises and Teams integration, the required license needs to be assigned for the AAD synced user.
 
 > [!IMPORTANT]
 > If you uninstall the Skype for Business client after you move a user to **Teams Only** mode, presence may stop working in Outlook and other Office apps. Presence works fine in Teams. To resolve this issue, select your profile picture in the top right-hand corner of Microsoft Teams and then select **Settings**. On the **General** tab under **Application**, select **Register Teams as the chat app for Office (requires restarting Office applications)**. After you select this option, close and re-open all Office apps, including Outlook. After you open Outlook, presence information will be available.


### PR DESCRIPTION
Scheduling a meeting with Outlook and the Teams add-in for the user itself is supported without EWS/OAuth etc. When it comes to delegation it's not possible to schedule a meeting on behalf without some basic requirements. The lack of information in our public docs leads into widely confusion in our customers. Espacially as a result of several C-19 Teams rollouts. Please add a hint here. THX

https://dev.azure.com/Supportability/UC/_wiki/wikis/UC.wiki/3769/Teams-Delegate-Meeting-Requirements-and-Limitations