### PR TITLE
Remove premier from the page

### DIFF
--- a/Teams/teams-first-overview.md
+++ b/Teams/teams-first-overview.md
@@ -49,7 +49,7 @@ To get started with your Teams First deployment you will need to meet at minimum
 > Tenants created after September 1, 2019 are provisioned in Teams Only mode.
 > 
 > [!IMPORTANT]
-> If you have Skype for Business Server deployed, and your tenant was provisioned AFTER September 1, 2019, please contact premier support to enable coexistence capabilities for Teams. Make sure your 'Organization wide upgrade policy' is set to 'Island mode' <span class="underline">before</span> you assign any Teams licenses to a user.
+> If you have Skype for Business Server deployed, and your tenant was provisioned AFTER September 1, 2019, please contact support to enable coexistence capabilities for Teams. Make sure your 'Organization wide upgrade policy' is set to 'Island mode' <span class="underline">before</span> you assign any Teams licenses to a user.
 
 ## Migration Starting points
 
@@ -228,7 +228,7 @@ Learn more here: <a href="https://docs.microsoft.com/microsoftteams/admin-settin
 
 1.  Meet pre-requisites detailed in the Start Here section above.
 
-2.  Switch tenant into Islands mode (for tenants provisioned AFTER 9/1/2019, please contact premier support to make this change)  
+2.  Switch tenant into Islands mode (for tenants provisioned AFTER 9/1/2019, please contact support to make this change)  
     [Setting your coexistence and upgrade settings](setting-your-coexistence-and-upgrade-settings.md)
 
 3.  Configure your tenant in accordance with your company's business/company policies  


### PR DESCRIPTION
Change "premier support" to "support". We don't have premier support only support services.