### PR TITLE
Escape characters not needed in code blocks

### DIFF
--- a/Skype/SfbOnline/set-up-your-computer-for-windows-powershell/download-and-install-the-skype-for-business-online-connector.md
+++ b/Skype/SfbOnline/set-up-your-computer-for-windows-powershell/download-and-install-the-skype-for-business-online-connector.md
@@ -35,7 +35,7 @@ The Skype for Business Online Connector module includes the **New-CsOnlineSessio
 The setup program copies the Skype for Business Online Connector module (and the **New-CsOnlineSession** cmdlet) to your computer. To access the module, start a Windows PowerShell session under administrator credentials, and then run the following command:
   
 ```PowerShell
-Import-Module "C:\\Program Files\\Common Files\\Skype for Business Online\\Modules\\SkypeOnlineConnector\\SkypeOnlineConnector.psd1"
+Import-Module "C:\Program Files\Common Files\Skype for Business Online\Modules\SkypeOnlineConnector\SkypeOnlineConnector.psd1"
 ```
 
 If you don't want to type this command every time you start Windows PowerShell, you can add the command to your Windows PowerShell profile. To do that, type the following command at the Windows PowerShell prompt and then press ENTER:


### PR DESCRIPTION
Inside the code block, the extra backslash is not needed and confusing.
Issue #4786  