### PR TITLE
Updated download links in teams-for-vdi.md

### DIFF
--- a/Teams/teams-for-vdi.md
+++ b/Teams/teams-for-vdi.md
@@ -127,8 +127,8 @@ To learn more about Teams and Microsoft 365 Apps for enterprise, see [How to exc
 
 1. Download the Teams MSI package that matches your VDI VM operating system using one of the following links:
 
-    - [32-bit version](https://statics.teams.cdn.office.net/production-windows/1.3.00.4461/Teams_windows.msi)
-    - [64-bit version](https://statics.teams.cdn.office.net/production-windows-x64/1.3.00.4461/Teams_windows_x64.msi)
+    - [32-bit version](https://teams.microsoft.com/downloads/desktopurl?env=production&plat=windows&managedInstaller=true&download=true)
+    - [64-bit version](https://teams.microsoft.com/downloads/desktopurl?env=production&plat=windows&arch=x64&managedInstaller=true&download=true)
 
     The minimum version of the Teams desktop app that's required is version 1.3.00.4461. (PSTN hold is not supported in earlier versions.)
 


### PR DESCRIPTION
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/4712

@LanaChin could you kindly double-check it?

I have updated the links with these:
https://docs.microsoft.com/microsoftteams/msi-deployment
I think in this way you always get the latest MSI.

Also, there was an issue where you updated the links:
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/4019
But in this way, we always need to update the links for each new version.

Thanks!