### PR TITLE
add dial-out to Zone A countries or regions policy

### DIFF
--- a/Teams/outbound-calling-restriction-policies.md
+++ b/Teams/outbound-calling-restriction-policies.md
@@ -31,7 +31,7 @@ Outbound call controls can be applied on a per-user basis and provide the follow
 
 |Control|Description|Control options|
 |:-----|:-----|:-----|
-|Audio Conferencing PSTN calls|Restricts the type of outbound </br>calls that are allowed from within </br>meetings organized by a user.|International and Domestic (default)</br>Domestic</br>None|
+|Audio Conferencing PSTN calls|Restricts the type of outbound </br>calls that are allowed from within </br>meetings organized by a user.|Any destination (default)</br>In the same country or region as the orgnizor </br> </br>Zone A countries or regions only </br>Don't allow|
 |End user PSTN calls|Restricts the type of calls </br>that can be made by a user.|International and Domestic (default)</br>Domestic</br>None|
 
    > [!NOTE]
@@ -88,3 +88,6 @@ The following table provides an overview of each policy.
 |    Identity='tag:DialoutCPCDomesticPSTNDisabled'    |    User in the conference can only dial out to   domestic numbers, and this user cannot make any outbound calls to PSTN number besides emergency numbers.    |
 |    Identity='tag:DialoutCPCDisabledPSTNDomestic'    |    User in the conference cannot make any dial   out, and this user can only make outbound call to domestic PSTN numbers.    |
 |    Identity='tag:DialoutCPCandPSTNDisabled'    |    User in the conference cannot make any dial   out, and this user cannot make any outbound calls to PSTN number besides emergency numbers.    |
+|    Identity='tag:DialoutCPCZoneAPSTNInternational'    |    User in the conference can only dial out to Zone A countries and regions, and this user can make outbound calls to international and domestic numbers.    |
+|    Identity='tag:DialoutCPCZoneAPSTNDomestic'    |    User in the conference can only dial out to Zone A countries and regions, and this user can only make outbound calls to domestic PSTN number.    |
+|    Identity='tag:DialoutCPCZoneAPSTNDisabled'    |    User in the conference can only dial out to Zone A countries and regions, and this user cannot make any outbound calls to PSTN number besides emergency numbers.    |

--- a/Teams/outbound-calling-restriction-policies.md
+++ b/Teams/outbound-calling-restriction-policies.md
@@ -34,8 +34,10 @@ Outbound call controls can be applied on a per-user basis and provide the follow
 |Audio Conferencing PSTN calls|Restricts the type of outbound </br>calls that are allowed from within </br>meetings organized by a user.|Any destination (default)</br>In the same country or region as the orgnizor </br> </br>Zone A countries or regions only </br>Don't allow|
 |End user PSTN calls|Restricts the type of calls </br>that can be made by a user.|International and Domestic (default)</br>Domestic</br>None|
 
+To find out which countries/regions are considered Zone A, see [Zone A countries/regions](../complimentary-dial-out-period.md).
+
    > [!NOTE]
-   > A call is considered domestic if the number dialed is in the same country where Office 365 has been set up for the organizer of the meeting (in the case of audio conferencing), or the end user (in the case of end user PSTN calls). 
+   > A call is considered domestic if the number dialed is in the same country/region where Office 365 has been set up for the organizer of the meeting (in the case of audio conferencing), or the end user (in the case of end user PSTN calls). 
 
 > [!NOTE]
 > [!INCLUDE [updating-admin-interfaces](includes/updating-admin-interfaces.md)]


### PR DESCRIPTION
@tonysmit please review.

I also want to add "([Learn more](https://docs.microsoft.com/en-US/microsoftteams/complimentary-dial-out-period))" after the option Zone A countries or regions only. But I don't know how to add a link there....Could you help with that?


Thanks,

Fan
