### PR TITLE
Added missing subnet

### DIFF
--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -281,6 +281,7 @@ The media traffic flows to and from a separate service in the Microsoft Cloud. T
 ### Office 365 and Office 365 GCC environments
 
 - 52.112.0.0/14 (IP addresses from 52.112.0.1 to 52.115.255.254).
+- 52.120.0.0/14 (IP addresses from 52.120.0.1 to 52.123.255.254).
 
 ### Office 365 GCC DoD environment
 


### PR DESCRIPTION
- 52.120.0.0/14 (IP addresses from 52.120.0.1 to 52.123.255.254).
This subnet has recently been added for IP media traffic. 

See here: https://docs.microsoft.com/en-us/microsoftteams/prepare-network
and here: https://docs.microsoft.com/en-us/office365/enterprise/urls-and-ip-address-ranges#skype-for-business-online-and-microsoft-teams