### PR TITLE
Added missing subnet.

### DIFF
--- a/Teams/direct-routing-plan-media-bypass.md
+++ b/Teams/direct-routing-plan-media-bypass.md
@@ -135,7 +135,9 @@ In media path for voice applications | Always | Never |
 Can do transcoding (B2BUA)\* | Yes | No, only relays audio between endpoints | 
 Number of instances worldwide and location | 8 total: 2 in US East and West; 2 in Amsterdam and Dublin; 2 in Hong Kong and Singapore; 2 in Japan  | Multiple
 
-The IP range is 52.112.0.0 /14 (IP addresses from 52.112.0.1 to 52.115.255.254). 
+The IP ranges are:
+- 52.112.0.0/14 (IP addresses from 52.112.0.1 to 52.115.255.254)
+- 52.120.0.0/14 (IP addresses from 52.120.0.1 to 52.123.255.254)
 
 \* Transcoding explanation: 
 


### PR DESCRIPTION
- 52.120.0.0/14 (IP addresses from 52.120.0.1 to 52.123.255.254).

This subnet has recently been added for IP media traffic.

See here: https://docs.microsoft.com/en-us/microsoftteams/prepare-network
and here: https://docs.microsoft.com/en-us/office365/enterprise/urls-and-ip-address-ranges#skype-for-business-online-and-microsoft-teams