### PR TITLE
[DO NOT MERGE] SEO edits firstline-workers-quickstart

### DIFF
--- a/Teams/firstline-workers-quickstart.yml
+++ b/Teams/firstline-workers-quickstart.yml
@@ -1,8 +1,8 @@
 ### YamlMime:Tutorial
 title: Firstline Worker Quick Start Guide
 metadata:
-  title: Firstline Worker Quick Start Guide
-  description: Set up an effective pilot for Firstline Workers based on agile principles and an iterative approach.
+  title: Quick start - Microsoft Teams Firstline Worker
+  description: Set up an effective pilot for Firstline Workers (such as shift, retail, or factory workers) based on agile principles and an iterative approach.
   audience: IT Pro
   level: Intermediate
   displayType: one-column
@@ -26,7 +26,7 @@ metadata:
 items:
 - durationInMinutes: 2
   content: |
-    In this training, we'll walk you through how to set up an effective pilot for Firstline Workers based on agile principles and an iterative approach.
+    In this training, we'll walk you through how to set up an effective pilot for Firstline Workers based on agile principles and an iterative approach. Firstline Workers might be factory workers, retail specialists, or any staff member who regularly engages with customers on behalf of your company.
     > [!NOTE]
     > Please review and complete the [Prerequisites and environmental dependencies for Teams](upgrade-plan-journey-prerequisites.md) prior to beginning this work.
 

--- a/Teams/firstline-workers-quickstart.yml
+++ b/Teams/firstline-workers-quickstart.yml
@@ -26,7 +26,8 @@ metadata:
 items:
 - durationInMinutes: 2
   content: |
-    In this training, we'll walk you through how to set up an effective pilot for Firstline Workers based on agile principles and an iterative approach. Firstline Workers might be factory workers, retail specialists, or any staff member who regularly engages with customers on behalf of your company.
+    In this training, we'll walk you through how to set up an effective pilot for Firstline Workers based on agile principles and an iterative approach. Firstline Workers are frontline workers who might be factory workers, retail specialists, healthcare specialists or any staff member who regularly engages with customers on behalf of your company.
+    
     > [!NOTE]
     > Please review and complete the [Prerequisites and environmental dependencies for Teams](upgrade-plan-journey-prerequisites.md) prior to beginning this work.
 


### PR DESCRIPTION
Edited metadata title to align with other quick start guides. Description edited to include keywords. Sentence added to introduction to add keywords.

Most of the additions are placed in a way that offers a definition of what a Firstline Worker is.

@DaniHalfin 