### PR TITLE
Update browser support to include video limits

### DIFF
--- a/Teams/includes/browser-support.md
+++ b/Teams/includes/browser-support.md
@@ -14,6 +14,8 @@ Teams fully supports the following Internet browsers, with noted exceptions for 
 
 <sup>2</sup> Blur my background isn't available when you run Teams in a browser. This feature is only available in the Teams desktop client.
 
+<sup>3</sup> Incoming video feeds are limited to the single active speaker's stream when you run Teams in a browser. The video grid is only available in the Teams desktop client.
+
 > [!NOTE]
 > As long as an operating system can run the supported browser, Teams is supported on desktop computers. For example, running Firefox on the Linux operating system is an option for using Teams.
 >


### PR DESCRIPTION
Added sup 3 to include that browsers only allow for a single incoming video stream from the active speaker. This is needed as folks are expecting to see 3x3 but that is not supported on the web (only mobile, Mac, and desktop)