### PR TITLE
Proposing adding max members in a priv channel

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -38,6 +38,7 @@ This article describes some of the limits, specifications, and other requirement
 |Number of teams an Office 365 organization can have    | 500,000&sup2;     |
 |Number of channels per team    | 200 (includes deleted channels)&sup3;         |
 |Number of Private channels per team    |30|
+|Number of members in a Private channel    |250|
 |Channel conversation post size | Approximately 28 KB per post<sup>4</sup> |
 
 &sup1; Any directory object in Azure Active Directory counts towards this limit. Global admins are exempt from this limit, as are apps calling Microsoft Graph using [application permissions](https://docs.microsoft.com/graph/permissions-reference).


### PR DESCRIPTION
Source https://docs.microsoft.com/en-us/MicrosoftTeams/private-channels

> Each team can have a maximum of 30 private channels and each private channel can have a maximum of 250 members. 

@LolaJacobsen @LanaChin Please review.

Related issue: https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/4998