### PR TITLE
Update direct-routing-plan.md

### DIFF
--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -317,7 +317,7 @@ Locations where both SIP proxy and media processor components deployed:
 
 Locations where only media processors are deployed (SIP flows via the closest datacenter listed above):
 - Japan (JP East and West datacenters)
-- Australia (AU East and West datacenters)
+- Australia (AU East and Southeast datacenters)
 
 
 


### PR DESCRIPTION
Correcting Australia DCs to refer to AU East and Southeast (there's no AU West Azure Datacentre)