### PR TITLE
Update communicate-with-users-from-other-organizations.md

### DIFF
--- a/Teams/communicate-with-users-from-other-organizations.md
+++ b/Teams/communicate-with-users-from-other-organizations.md
@@ -67,7 +67,7 @@ If you're ready to turn on guest access in your organization, start with the [Gu
 | Individual user can be blocked | No | Yes |
 | @mentions are supported | Yes<sup>4</sup> | Yes |
 | Make private calls | Yes | Yes |
-| View the phone number for dial-in meeting participants | No | Yes |
+| View the phone number for dial-in meeting participants | No<sup>5</sup> | Yes |
 | Allow IP video | Yes | Yes |
 | Screen sharing mode | Yes<sup>4</sup> | Yes |
 | Allow meet now | No | Yes |
@@ -81,7 +81,8 @@ If you're ready to turn on guest access in your organization, start with the [Gu
 <sup>1</sup> Provided that the user has been added as a guest and is signed in as a guest to the guest tenant.<br>
 <sup>2</sup> Only by email or Session Initiation Protocol (SIP) address.<br>
 <sup>3</sup> External (federated) chat is 1:1 only.<br>
-<sup>4</sup> Supported for 1:1 chat for Teams Only to Teams Only users from two different organizations. 
+<sup>4</sup> Supported for 1:1 chat for Teams Only to Teams Only users from two different organizations.
+<sup>5</sup> If you are interested to not reveal PSTN numbers to external users, make sure that when enabling entry/exit announcements, the announcement type is set to Tones. See more [here](https://docs.microsoft.com/en-us/MicrosoftTeams/turn-on-or-off-entry-and-exit-announcements-for-meetings-in-teams)
 
 ## Related topics
 

--- a/Teams/communicate-with-users-from-other-organizations.md
+++ b/Teams/communicate-with-users-from-other-organizations.md
@@ -82,7 +82,7 @@ If you're ready to turn on guest access in your organization, start with the [Gu
 <sup>2</sup> Only by email or Session Initiation Protocol (SIP) address.<br>
 <sup>3</sup> External (federated) chat is 1:1 only.<br>
 <sup>4</sup> Supported for 1:1 chat for Teams Only to Teams Only users from two different organizations.
-<sup>5</sup> If you don't want to reveal PSTN numbers to external users, when you turn on entry and exit announcements, select **Tones** for the announcement type. To learn more, read [Turn on or off entry and exit announcements for meetings in Microsoft Teams](turn-on-or-off-entry-and-exit-announcements-for-meetings-in-teams.md).
+<sup>5</sup> If you don't want to reveal external PSTN phone numbers to external users, when you turn on entry and exit announcements, select **Tones** for the announcement type. To learn more, read [Turn on or off entry and exit announcements for meetings in Microsoft Teams](turn-on-or-off-entry-and-exit-announcements-for-meetings-in-teams.md).
 
 ## Related topics
 

--- a/Teams/communicate-with-users-from-other-organizations.md
+++ b/Teams/communicate-with-users-from-other-organizations.md
@@ -82,7 +82,7 @@ If you're ready to turn on guest access in your organization, start with the [Gu
 <sup>2</sup> Only by email or Session Initiation Protocol (SIP) address.<br>
 <sup>3</sup> External (federated) chat is 1:1 only.<br>
 <sup>4</sup> Supported for 1:1 chat for Teams Only to Teams Only users from two different organizations.
-<sup>5</sup> If you are interested to not reveal PSTN numbers to external users, make sure that when enabling entry/exit announcements, the announcement type is set to Tones. See more [here](https://docs.microsoft.com/en-us/MicrosoftTeams/turn-on-or-off-entry-and-exit-announcements-for-meetings-in-teams)
+<sup>5</sup> If you don't want to reveal PSTN numbers to external users, when you turn on entry and exit announcements, select **Tones** for the announcement type. To learn more, read [Turn on or off entry and exit announcements for meetings in Microsoft Teams](turn-on-or-off-entry-and-exit-announcements-for-meetings-in-teams.md).
 
 ## Related topics
 


### PR DESCRIPTION
The context is following: we recently shipped another feature - PSTN entry/exit chimes which can read the full number of the PSTN user joining into the meeting if the type of announcement is set to "Names or phone numbers":

https://docs.microsoft.com/en-us/MicrosoftTeams/turn-on-or-off-entry-and-exit-announcements-for-meetings-in-teams
    
The enty/exit announcement feature can't read a number in 2 distinct ways based on who is hearing the announcement. Similar to how we display the number masked or unmasked depending on who's looking at the UI. 

Therefore, we should add guidance for tenants who care a lot about PSTN number masking for added privacy so that they set the announcement type to Tones and it never happens that the external users hear or see the phone number of the dialed in users