### PR TITLE
Proposing clarifying to public live event

### DIFF
--- a/Teams/quick-start-meetings-live-events.md
+++ b/Teams/quick-start-meetings-live-events.md
@@ -30,7 +30,7 @@ There are 2 ways to meet in Microsoft Teams - meetings and live events. Use this
 
 ## Get licenses for meetings and live events
 
-Anyone can attend a Teams meeting or live event for free - no license is required. Attendees join a Teams meeting or live event by clicking the **Join** button in Teams or the meeting invitation. Meeting audio is part of a Teams meeting, but if you want people to be able to dial in to a meeting by phone, you'll need to provide a dial-in number. 
+Anyone can attend a Teams meeting or public live event for free - no license is required. Attendees join a Teams meeting or live event by clicking the **Join** button in Teams or the meeting invitation. Meeting audio is part of a Teams meeting, but if you want people to be able to dial in to a meeting by phone, you'll need to provide a dial-in number. 
 
 For the people who will organize, schedule, and host meetings or live events, they'll need one of the Microsoft 365 or Office 365 licenses listed in the table below. If you're already using Teams, you probably have the license you need for organizing and hosting meetings and live events. 
 


### PR DESCRIPTION
@LolaJacobsen please review if you agree to this change, this is based on 
https://support.microsoft.com/en-us/office/get-started-with-microsoft-teams-live-events-d077fec2-a058-483e-9ab5-1494afda578a?ui=en-us&rs=en-us&ad=us#bkmk_attendliveevents

> **Public events**
> 
> If an event is public, anyone who has the link can attend without logging in.
> 
> **Private events**
> 
> If attendance is restricted to your org or to specific people and groups, attendees will need to log in to join.
> 
> If the event is produced in Teams, they'll need a license that includes Teams. If it's produced externally, they'll need one that includes Microsoft Stream.

Related issue https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/4753