### PR TITLE
Edit pass for exchange online migration article DO NOT MERGE

### DIFF
--- a/Skype/SfBServer2019/plan/exchange-unified-messaging-online-migration-support.md
+++ b/Skype/SfBServer2019/plan/exchange-unified-messaging-online-migration-support.md
@@ -19,14 +19,14 @@ description: "Microsoft is retiring the Exchange Unified Messaging Online (ExchU
 > **The Unified Messaging service in Exchange Online is out of support as of February 28, 2020, 5 PM Pacific Time. All voicemail accounts have been migrated to Cloud Voicemail service by Microsoft. Any remaining auto attendant traffic won't be monitored and might be disrupted at any time.**
 
 In reference to the [announcement](https://blogs.technet.microsoft.com/exchange/2019/02/08/retiring-unified-messaging-in-exchange-online/) on February 8, 2019, Microsoft is retiring the Exchange Unified Messaging Online (ExchUMO) service by February 28, 2020. This article offers a summary of what affected customers should know and do to plan for their business continuity.
- 
+
 ExchUMO is deployed by customers for voicemail, auto attendant, Call Queue, and fax integration services. Microsoft plans to help customers migrate to Phone System services that already support thousands of customers on Skype for Business Online and Microsoft Teams.
 
 Voicemail is primarily a Microsoft-driven migration; admin involvement and/or investment might be required for a subset of customers. Auto attendant is an admin-driven migration; you will need to re-create the existing ExchUMO auto attendant trees in the Cloud Auto Attendant cloud service. Customers who consume any of the ExchUMO features with a third-party PBX will not be migrated to Skype cloud services because they do not support third-party PBX systems. A retirement plan for third-party support was announced in [this blog](https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/New-date-for-discontinuation-of-support-for-Session-Border/ba-p/607853), and customers in this deployment model can migrate their users to one of Microsoft’s Unified Communications platforms/services or acquire a third-party voicemail and/or auto attendant solution for these users. Fax integration is not supported in the cloud-based services; customers will need to migrate to a third-party solution.
 
-### Who is affected?
+## Who is affected?
 
-Customers who are consuming any of the following features from Exchange Unified Messaging Online service are affected:
+Customers using any of the following features from the Exchange Unified Messaging Online service are affected:
 
 - Voicemail service
 - Auto Attendant service
@@ -34,13 +34,13 @@ Customers who are consuming any of the following features from Exchange Unified 
 - Fax integration
 
 > [!Note]
-> Customers who are using any of the Exchange Server on-premises with Unified Messaging are not affected. 
+> Customers who are using any of the Exchange Server on-premises with Unified Messaging are not affected.
 
 Learn more about the user and admin experience impact in [User experience impact](#user-experience-impact).
 
 ## Migration plan overview
 
-Microsoft has identified various customer deployments that are consuming features from ExchUMO and will be helping customers migrate based on the following plan. 
+Microsoft has identified various customer deployments that are consuming features from ExchUMO and will be helping customers migrate based on the following plan.
 
 |Customer group |Timeline  |Details  |
 |---------|---------|---------|
@@ -48,60 +48,62 @@ Microsoft has identified various customer deployments that are consuming feature
 |Customers with prerequisites<br><br>Features to migrate:<br><ul><li>Voicemail<li>Auto attendant<li>Call Queue</ul> |  May — December 2019 |Examples: <br><ul><li>Hybrid configuration is not  complete<li>Hybrid PSTN numbers are not set up</ul>|
 |Customers who require admin involvement & customer investment<br><br>Features to migrate:<ul><li>voicemail<li>Auto attendant<li>Call Queues<li>Fax integration</ul>| By February 2020  | Examples: <br><ul><li>ExchUMO service is consumed by third party PBX<li>Customers with PSTN Subscriber Access requirements<li>Customers on SFB 2010 (not-supported)<li>Fax integration</ul> |
 
-## Voicemail migration steps
+## Voicemail migration guidelines
 
-1.	**Get informed**
+### Get informed
+
+Familiarize yourself with the [blog announcement](https://blogs.technet.microsoft.com/exchange/2019/02/08/retiring-unified-messaging-in-exchange-online/) and this article to plan a smooth migration for your users. See [Check Skype for Business voicemail and options](https://support.office.com/article/check-skype-for-business-voicemail-and-options-2deea7f8-831f-4e85-a0d4-b34da55945a8) for details on the Phone System Voicemail capabilities.  
+
+### Establish a Skype for Business hybrid topology
+
+If you do not have a Skype for Business hybrid topology established, you need to do that to enable a smooth migration of your voicemail users. See [Configure Skype for Business hybrid](../../SfbHybrid/hybrid/configure-federation-with-skype-for-business-online.md) for more details.
+
+> [!Note]
+> You do not need to migrate your users online for the voicemail service migration. However, for on-premises users to leverage Phone System voicemail service, a hybrid topology must be established.
+
+### Plan your auto attendant migration
+
+Admins can start migrating their auto attendants from ExchUMO to the Cloud auto attendant at any time. See [Set up a Cloud auto attendant](https://docs.microsoft.com/microsoftteams/create-a-phone-system-auto-attendant) for more details.
+
+Microsoft continues to deliver additional auto attendant capabilities that customers might consider required for their migration. Admins should evaluate the feature set and migrate their auto attendant instances accordingly. For a feature-list comparison, see the [ExchUMO and Azure cloud-based services feature matrix](#exchumo-and-azure-cloud-based-services-feature-matrix).
+
+### Plan for your voicemail post-migration validation and testing
+
+Voicemail migration is Microsoft driven. Admins are not required to do anything, given that the pre-requisite hybrid topology is established. Microsoft performs the required validation and testing to make sure users’ voicemail migration is not disrupted. Admins are encouraged to perform testing and validation on their side. See [Suggested test plan and post-migration validation for admins](#suggested-test-plan-and-post-migration-validation-for-admins) for a recommended test plan.
+
+> [!Note]
+> Lync Server 2010 is not supported. If you are in a 2010 server deployment, you should plan a server upgrade or consider migrating your users to Microsoft Teams or Skype for Business Online.  
+
+### Monitor the Admin Notification Center
+
+Watch for a notice in the Admin Notification Center with further details and a timeline regarding your users' migration. Notifications are sent at least 30 days before your migration period.
+
+> [!Note]
+> If you received a notification with your users’ migration timeline and would like to postpone your migration for a business-critical reason, you can do so by contacting Microsoft Support. You cannot postpone your migration beyond the retirement date of February 28, 2020. For customers who might have more questions, please contact your account team or Microsoft Support. Customers already using Microsoft 365 or Office 365 can submit a support case through the Microsoft 365 admin center.
+
+### Consider opting in for a planned migration
+
+You can opt in for a planned Voicemail service migration to CVM. Before opting in, review the details of this article, especially the following sections:
+
+- Migration steps (this section)
+- ExchUMO and Azure cloud-based services feature matrix
+- User experience impact
+
+When you choose a managed migration, you will not receive a pre-migration 30-days notification in the Microsoft 365 admin portal message center.
+
+To opt in for a planned migration, send an email request from your administrator's email address to [cvm@microsoft.com](mailto:cvm@microsoft.com) with the following information:
+
+- Preferred date (Tuesdays): migration waves are executed every Tuesday. Please select a date on a Tuesday that is not beyond 12/3/2019.
  
-    Familiarize yourself with the [blog announcement](https://blogs.technet.microsoft.com/exchange/2019/02/08/retiring-unified-messaging-in-exchange-online/) and this article to plan a smooth migration for your users. See [Check Skype for Business voicemail and options](https://support.office.com/article/check-skype-for-business-voicemail-and-options-2deea7f8-831f-4e85-a0d4-b34da55945a8) for details on the Phone System Voicemail capabilities.  
- 
-2.	**Establish a Skype for Business hybrid topology**
+- Tenant ID: 32 characters number in this format 0046728c-688a-4472-a38f-098fec60ac6x. You can find your tenant ID in the Microsoft 365 admin portal under Azure AD, or using the following PowerShell cmdlet: `Get-CsTenant | Select ObjectId`
 
-    If you do not have a Skype for Business hybrid topology established, you need to do that to enable a smooth migration of your voicemail users. See [Configure Skype for Business hybrid](../../SfbHybrid/hybrid/configure-federation-with-skype-for-business-online.md) for more details. 
-
-    > [!Note]
-    > You do not need to migrate your users to online for the voicemail service migration. However, for on-premises users to leverage Phone System voicemail service, a hybrid topology is must be established.
-
-3. **Plan your auto attendant migration**
-    
-    Admins can start migrating their auto attendants from ExchUMO to the Cloud auto attendant at any time. See [Set up a Cloud auto attendant](https://docs.microsoft.com/microsoftteams/create-a-phone-system-auto-attendant) for more details. Microsoft continues to deliver additional auto attendant capabilities that customers may consider required for their migration, admins should evaluate the feature set and migrate their auto attendant instances accordingly. For feature-list comparison, see the [ExchUMO and Azure cloud-based services feature matrix](#exchumo-and-azure-cloud-based-services-feature-matrix).
-
-4. **Plan for your voicemail post-migration validation and testing**
-
-    Voicemail migration is Microsoft driven. Admins are not required to do anything, given that the pre-requisite hybrid topology is established. Microsoft performs the required validation and testing to make sure users’ voicemail migration is not disrupted. Admins are encouraged to perform testing and validation on their side. See [Suggested test plan and post-migration validation for admins](#suggested-test-plan-and-post-migration-validation-for-admins) for a recommended test plan. 
-
-    > [!Note]
-    > Lync Server 2010 is not supported. If you are in a 2010 server deployment, you should plan a server upgrade or consider migrating your users to Microsoft Teams or Skype for Business Online.  
-
-5. **Monitor the Admin Notification Center**
-
-    Look out for a notice in the Admin Notification Center with further details and timeline regarding your users' migration. Notifications are sent at least 30 days before your migration period. 
-
-    > [!Note]
-    > If you received a notification with your users’ migration timeline and would like to postpone your migration for a business-critical reason, you can do so by contacting Microsoft Support. Note that you cannot postpone your migration beyond the retirement date, February 28, 2020. For customers who may have more questions, please contact your account team or Microsoft Support. Customers already using Microsoft 365 or Office 365 can submit a support case through the Microsoft 365 admin center. 
-
-6. **Consider opting in for a planned migration**
-
-    You can opt in for a planned Voicemail service migration to CVM. Before opting in, review the details of this article, especially the following sections:
-
-    - Migration steps (this section)
-    - ExchUMO and Azure cloud-based services feature matrix
-    - User experience impact
-
-    When you choose a managed migration you will not receive a pre-migration 30-days notification in the Microsoft 365 admin portal message center.
- 
-    To opt in for a planned migration, send an email request from your administrator's email address to [cvm@microsoft.com](mailto:cvm@microsoft.com) with the following information:
-
-    - Preferred date (Tuesdays): migration waves are executed every Tuesday. Please select a date on a Tuesday that is not beyond 12/3/2019.
- 
-    - Tenant ID: 32 characters number in this format 0046728c-688a-4472-a38f-098fec60ac6x. You can find your tenant ID in the Microsoft 365 admin portal under Azure AD, or using the following PowerShell cmdlet: `Get-CsTenant | Select ObjectId`
- 
-    You receive an email confirmation once your tenant is successfully migrated.
+You will receive an email confirmation once your tenant is successfully migrated.
 
 ## Auto attendant migration guidelines
 
-Microsoft 365 and Office 365 organization administrators are required to re-create their Exchange UM Online auto attendants in the Microsoft Cloud Auto Attendant service and switch their on-premises phone numbers to them before February 28, 2020, which is when Exchange UMO service will be retired. This is the recommended guideline to successfully migrate and test new Cloud auto attendants. If you have a large number of auto attendants, you can use the [Exchange UM Auto Attendant to Cloud Auto Attendant Migration scripts](https://github.com/NathanJBennett/ExUMAAMigrationToCloudAA) to simplify the bulk migration of auto attendants.
+Microsoft 365 and Office 365 organization administrators are required to re-create their Exchange UM Online auto attendants in the Microsoft Cloud Auto Attendant service and switch their on-premises phone numbers to them before the Exchange UMO service retirement date of February 28, 2020. This is the recommended guideline to successfully migrate and test new Cloud auto attendants. If you have a large number of auto attendants, you can use the [Exchange UM Auto Attendant to Cloud Auto Attendant Migration scripts](https://github.com/NathanJBennett/ExUMAAMigrationToCloudAA) to simplify the bulk migration of auto attendants.
 
-### Setup
+### Auto attendant setup
 
 We strongly advise that you start the setup of your new auto attendants early to avoid last minute issues and to get familiar with the functionality and experience of the Cloud Auto Attendant service. For auto attendants that require one or more gap features, you can create and test the auto attendants when the gap features are available to prepare for deployment. For more information about gap features, see the [Appendix](#appendix).
 
@@ -110,13 +112,13 @@ We strongly advise that you start the setup of your new auto attendants early to
 3. Follow the instructions in [Plan Cloud auto attendants](../../SfbHybrid/hybrid/plan-cloud-auto-attendant.md) and [Set up a Cloud auto attendant](https://docs.microsoft.com/microsoftteams/create-a-phone-system-auto-attendant) to create auto attendants by using the Microsoft Teams admin center or Powershell.
 4. Review your greetings if the menu options changed.
 5. Configure transfers to your response groups by using the "Auto Attendant Call Transfer to PSTN" workaround in the [Known issues](#known-issues) section of this article.  
-6. Test the new auto attendants. To test, call them internally or assign a test phone number.  
+6. Test the new auto attendants by calling them internally or assigning a test phone number.  
 
 ### Cutover
 
 1. Switch your phone numbers from Exchange UMO auto attendants to the new auto attendants.
 2. Move the SIP URI from the contact object to the resource account.
-3. Test and validate your auto attendants by using the newly-assigned phone numbers. 
+3. Test and validate your auto attendants by using the newly assigned phone numbers.
 
 ## Appendix
 
@@ -194,14 +196,14 @@ We strongly advise that you start the setup of your new auto attendants early to
 
 ### Suggested test plan and post-migration validation for admins
 
-To validate that your users have been migrated to Cloud Voicemail,   leave a voicemail to a user and check the message body in Outlook.  Cloud Voicemail messages have a footer that reads:
+To validate that your users have been migrated to Cloud Voicemail, leave a voicemail to a user and check the message body in Outlook. Cloud Voicemail messages have a footer that reads:
 
-**Thank you for using Transcription! If you don't see a transcript above, it's because the audio quality was not clear enough to transcribe.**
+"Thank you for using Transcription! If you don't see a transcript above, it's because the audio quality was not clear enough to transcribe."
 
 When testing voicemail functionality after your users have been migrated, make sure to consider the following scenarios:
 
-- Validate voicemail access across all endpoint types in your organization: apps and IP phones. 
-- Validate with sample users that the configured personalized greetings are played to callers.   
+- Validate voicemail access across all endpoint types in your organization, such as apps and IP phones.
+- Validate with sample users that the configured personalized greetings are played to callers.
 - If your organization has a legal or compliance requirement to disable transcription for users, make sure it is disabled post migration. For more details, see [Set up Cloud Voicemail](/microsoftteams/set-up-phone-system-voicemail).
 - If you have previously configured Exchange VM policies and rules, make sure they are effective.
 - Familiarize yourself with the Cloud Voicemail service PowerShell cmdlets for changing user settings.  
@@ -217,44 +219,49 @@ The following is an overview of end-user voicemail migration experience.
 |Access to previous messages | No change<br>Users have access to their previous voicemail messages in all supported endpoints. |
 |Receiving VM in outlook, SFB Apps| No change<br>Users continue to receive their voicemail messages in all supported endpoints. |
 |Transcription | Enhanced<br>CVM transcription has a much higher accuracy rate and supported languages than ExchUMO. |
-|User setting | New experience<br>Users are able to change their preferences from a User Setting Portal (USP). Users can access their USP from a hyperlink in their voicemail email, or the User-Settings button on their SFB client; https://aka.ms/vmsettings.   
+|User setting | New experience<br>Users are able to change their preferences from a User Setting Portal (USP). Users can access their USP from a hyperlink in their voicemail email, or the User-Settings button on their SFB client; https://aka.ms/vmsettings.
  |Features| Please see the feature-set comparison for details. |
 |Outlook rules for VM messages | No change<br>Previously created rules will apply to CVM messages after migration.
  |
 
-#### User management and provisioning in CVM
+### User management and provisioning in CVM
 
 New Skype for Business users will be automatically provisioned for Cloud voicemail when created. No additional admin work or license is required to provision new voicemail users. See [Set up Cloud Voicemail](/microsoftteams/set-up-phone-system-voicemail) to learn about policy management for existing and new users.
 
-#### Admin Auto Attendant management experience
+### Admin Auto Attendant management experience
 
 To learn more about auto attendants, see [Set up a Cloud auto attendant](https://docs.microsoft.com/microsoftteams/create-a-phone-system-auto-attendant).
 
-#### Known issues
+### Known issues
 
-**Disable Subscriber Access after migration to avoid greeting inconsistency**
-Subscriber access might continue to work for your tenant until the service is completely retired, even after all of your users has been migrated to Cloud Voicemail. To avoid user confusion and inconsistent experience, please disable subscriber access since greetings changed after migration from there will not take affect. To do that, remove the EXUM contact for each subscriber access line using Get-CsExUmContact | ?{$_.IsSubscriberAccess -eq $true} | Remove-CsExUmContact 
+#### Greeting inconsistencies
 
-**Auto Attendant Call Transfer to PSTN**
-Customers are encouraged to configure a temporarily workaround to fulfill the requirements of transferring an auto attendant call to an external PSTN number, or to an RGS instance. 
- 
-An issue was identified during quality assurance with the Transfer out to PSTN number feature, which is not going to be fixed in-time for customers to start migrating off Exchange UMO service before its scheduled retirement date of Feb 28th, 2020. As a workaround, administrators can transfer auto attendant callers to an on-premise virtual user with an active Call Forward setting to the desired PSTN phone number or RGS phone number. 
- 
-Expected Experience
-- Administrators do not need to license the virtual user, since this is a workaround solution 
-- Administrators can manipulate the caller ID that the PSTN receiver will see by assigning the desired number to the virtual user, or using the SBC digit manipulation capabilities
-- PSTN Callers will not experience any delay during the call transfer, and they will continue to see the caller ID of the auto attendant after the transfer is successful  
+Subscriber access might continue to work for your tenant until the service is completely retired, even after all your users have been migrated to Cloud Voicemail. To avoid user confusion and an inconsistent experience, disable the subscriber access since the greetings change after migration. To do that, remove the EXUM contact for each subscriber access line using `Get-CsExUmContact | ?{$_.IsSubscriberAccess -eq $true} | Remove-CsExUmContact`.
 
-**Shared mailbox:**
-A shared mailbox that is configured using Exchange UM Online will continue to receive messages after being migrated to CVM, and will continue to be accessible to users via Outlook. However, access to change the greeting messages of these mailboxes will not be available once migrated to CVM. Customers with shared mailboxes that are used to capture auto attendant callers should leverage the Auto Attendants and Call Queues Shared Mailbox capabilities once released (ETA October 2019).
+#### Auto Attendant Call Transfer to PSTN
+
+Customers are encouraged to configure a temporary workaround to fulfill the requirements of transferring an auto attendant call to an external PSTN number or to an RGS instance.
+
+An issue was identified during quality assurance with the "Transfer out to PSTN number" feature, which will not be fixed in time for customers to start migrating off the Exchange UMO service before its scheduled retirement date of Feb 28th, 2020. As a workaround, administrators can transfer auto attendant callers to an on-premise virtual user with an active Call Forward setting to the desired PSTN phone number or RGS phone number. The expected experience is:
+
+- Administrators will not need to license the virtual user since this is a workaround solution.
+- Administrators can manipulate the caller ID that the PSTN receiver sees by assigning the desired number to the virtual user or using the SBC digit manipulation capabilities.
+- PSTN Callers will not experience any delay during the call transfer and will continue to see the caller ID of the auto attendant after the transfer is successful.
+
+#### Shared mailbox is still accessible
+
+A shared mailbox configured using Exchange UM Online continues to receive messages after the migration to CVM and be accessible to users via Outlook. However, access to change the greeting messages of these mailboxes will not be available once migrated to CVM. Customers with shared mailboxes that are used to capture auto attendant callers should leverage the Auto Attendants and Call Queues Shared Mailbox capabilities once released (ETA October 2019).
   
-**Upgrade to Teams banner on SFB client:**
-The CVM service is based on Microsoft Teams infrastructure; calls to it from Skype for Business client may cause an information banner to be displayed on the client that reads:
+#### "Username is not using Skype for Business" banner displays
+
+The CVM service is based on the Microsoft Teams infrastructure, and calls from a Skype for Business client might cause an information banner to display on the client that reads:
 "Username is not using Skype for Business. For a richer experience, switch to Teams or start a Skype meeting."
 Make sure to update your users' Skype for Business client to the latest C2R client update to prevent this banner from appearing.
   
-**Setup your voicemail will take you to OWA:**
-Clicking on "Set Up Voice Mail" from the client will continue to take Skype for Business Server 2015/2013 customers to the Office Web Access (OWA) portal page after migration to CVM. All settings have been removed from the Voicemail tab in OWA, and a banner will be displayed with a redirect link to take users to the CVM user settings portal.
- 
-**Change greeting mobile access:**
-PSTN subscriber access is not supported in CVM. For users that need to change their greeting remotely, a "Change your greeting" menu option is added to the voicemail IVR service for mobile clients. Users can call this service by pressing and holding the "1" key on the mobile client dial-pad.
+#### "Set Up Voice Mail" takes you to OWA
+
+Clicking **Set Up Voice Mail** from the client will continue taking Skype for Business Server 2015/2013 customers to the Office Web Access (OWA) portal page after migration to CVM. All settings have been removed from the Voicemail tab in OWA and a banner will display with a redirect link to take users to the CVM user settings portal.
+
+#### Changing greeting remotely
+
+PSTN subscriber access is not supported in CVM. For users that need to change their greeting remotely, a "Change your greeting" menu option has been added to the voicemail IVR service for mobile clients. Users can call this service by pressing and holding the "1" key on the mobile client dial-pad.


### PR DESCRIPTION
Edit pass for the Exchange Unified Messaging Online migration support article.

Changed the headings in the "Voicemail migration steps" section. This was constructed as an ordered list, but didn't seem to fit the MS Style Guide's definition of what an ordered list should be. I changed the step format to standard level-3 headings and changed the level-2 heading to "Voicemail migration guidelines." 

I changed some heading levels based on whether the information looked like it was separate from the previous heading (not a subheading), but the author should verify.

The "Known issues" section will need a careful review. This is where I found the most inconsistencies in language. I changed the issues to use standard headings and edited them to describe the issues themselves, rather than the workarounds. This could also help with SEO. If the author did not intend this, I would recommend changing the main H3 to "Workarounds for known issues," and I would revert the headings back to the original.

In "Greeting inconsistencies" of "Known issues", there is what appears to be a Powershell cmdlt. I changed the text format to match a cmdlt in a previous section, but the author will want to verify that's it's not some other kind of code.

All other edits were minor and made for clarity and style.