### PR TITLE
SEO edits for Shifts for Teams Landing Page

### DIFF
--- a/Teams/expand-teams-across-your-org/shifts-for-teams-landing-page.md
+++ b/Teams/expand-teams-across-your-org/shifts-for-teams-landing-page.md
@@ -1,6 +1,6 @@
 ---
 title: Shifts for Teams
-description: Get the admin guidance you need to set up and manage Shifts, the schedule management tool, in Teams.
+description: Use the list of links on this page to find the admin guidance for setting up and managing Shifts, or migrate from StaffHub to Shifts in Teams.
 layout: LandingPage
 ms.topic: landing-page
 author: lanachin
@@ -17,6 +17,7 @@ ms.collection:
 search.appverid: MET150
 appliesto: 
   - Microsoft Teams
+ms.custom: seo-marvel-jun2020
 ---
 
 # Shifts for Teams


### PR DESCRIPTION
Edited the description for SEO. The SEO expert also recommended adding a description under one of the headings to call out a search term (StaffHub alternative), but I felt it would disrupt the flow of the page too much. Or possibly break it. It also might confuse customers, since Shifts is not an alternative to StaffHub, but its replacement.

@DaniHalfin 