### PR TITLE
Corrected typo from "o36" to "o365"

### DIFF
--- a/Teams/security-compliance-overview.md
+++ b/Teams/security-compliance-overview.md
@@ -99,7 +99,7 @@ Retention policies in Microsoft Teams allows you to both retain data that's impo
 
 Data Loss Prevention (DLP) in Microsoft Teams, as well as the larger DLP story for Microsoft 365 or Office 365, revolves around business readiness when it comes to protecting sensitive documents and data. Whether you have concerns around sensitive information in messages or documents, DLP policies will be able to help ensure your users don't share this sensitive data with the wrong people.
 
-For information on Data Loss Prevention in Teams, please review [DLP for Microsoft Teams](https://docs.microsoft.com/microsoft-365/compliance/dlp-microsoft-teams). A good article for O36 DLP concerns is [Overview of data loss prevention](https://docs.microsoft.com/microsoft-365/compliance/data-loss-prevention-policies).
+For information on Data Loss Prevention in Teams, please review [DLP for Microsoft Teams](https://docs.microsoft.com/microsoft-365/compliance/dlp-microsoft-teams). A good article for O365 DLP concerns is [Overview of data loss prevention](https://docs.microsoft.com/microsoft-365/compliance/data-loss-prevention-policies).
 
 ### eDiscovery
 


### PR DESCRIPTION
Corrected typo from "o36" to "o365" in second paragraph of DLP section.