### PR TITLE
Update Plan.md

### DIFF
--- a/Skype/SfbServer/management-tools/call-quality-dashboard/plan.md
+++ b/Skype/SfbServer/management-tools/call-quality-dashboard/plan.md
@@ -314,6 +314,9 @@ Three domain service accounts are recommended on the principle of least privileg
   
 - One that already has both a login security principal for QoE Metrics database (with db_datareader privilege) and a login security principal in QoE Archive SQL Server Instance (needed to create a Linked Server object during setup). This account will be used to run "QoE Archive Data" step of the SQL Server Agent job.
     
+    > [!NOTE]
+    > If you are working in a heavily locked down environment, you need to check that this service account is indeed granted “Logon as a batch job” and “Allow log on locally” user rights on both the QoE Metrics Monitoring database SQL Server and the QoE Archive SQL Server.
+    
 - One that will be used to run "Process Cube" step of the SQL Server Agent job. Setup will create a login security principal to QoE Archive database (with read and write privilege) and also create a member in the QoE Role (with full control privilege) for the Cube.
     
 - One that will be used to run IIS Worker Process for the web portals and web APIs. Setup will create a login security principal to QoE Archive database (with read privilege), a login security principal to Repository database (with read and write privilege) , and a member in QoERole (with full control privilege) for the Cube. 


### PR DESCRIPTION
Many installations are failing in heavily locked down customer environments due to the fact that the service account used to run "QoE Archive Data" step of the SQL Server Agent job was prevented to “Logon as a batch job” and “Allow log on locally” via Domain GPOs. Once these user rights were assigned and granted, CQD Setup was successful.