### PR TITLE
Update limits specifications Meeting Limit

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -106,7 +106,7 @@ Channel names also can't start with an underscore (_) or period (.), or end with
 
 |Feature     | Maximum limit |
 |------------|---------------|
-|Number of people in a meeting (can chat and call in)  | 250    |
+|Number of people in a meeting (can chat and call in)  | 300    |
 |Number of people in a video or audio call from chat | 20 |
 |Max PowerPoint File Size | 2GB|
 |Teams keeps [meeting recordings](cloud-recording.md) that don't get uploaded to Microsoft Stream, available for local download | 20 days |


### PR DESCRIPTION
Updating Number of people in a meeting (can chat and call in) from 250 to 300 (c/o Siunie Sutjahjo)