### PR TITLE
Update URL; point to Teams admin center, not main

### DIFF
--- a/Teams/turn-on-or-off-entry-and-exit-announcements-for-meetings-in-teams.md
+++ b/Teams/turn-on-or-off-entry-and-exit-announcements-for-meetings-in-teams.md
@@ -38,7 +38,7 @@ The conferencing bridge answers a call for a user who is dialing in to a meeting
 
 You must be an admin to make these changes.
 
-1. Log in to the admin center at <a href="https://go.microsoft.com/fwlink/p/?linkid=2024339" target="_blank">https://admin.microsoft.com</a>.
+1. Log in to the admin center at <a href="https://admin.teams.microsoft.com" target="_blank">https://admin.teams.microsoft.com</a>.
 
 2. In the left navigation, go to **Meetings** > **Conference Bridges**. 
 


### PR DESCRIPTION
I'm not sure how to reverse this URL into a fancy go.microsoft.com one, but the current URL and text points to the main admin center, not the Teams-specific one mentioned in the comments that follow.