### PR TITLE
Corrected how Remote PowerShell is enabled

### DIFF
--- a/Teams/rooms/rooms-operations.md
+++ b/Teams/rooms/rooms-operations.md
@@ -101,7 +101,7 @@ For example, you can enable Remote PowerShell as follows:
 1. Sign in as Admin on a Microsoft Teams Rooms device.
 2. Open an elevated PowerShell command prompt.
 3. Enter the following command: `Enable-PSRemoting -SkipNetworkProfileCheck -Force`
-4. Open the Local Security Policy and add the *Administrators* security group to *Security Settings > Local Policies > User Rights Assignment > Access this computer from the network*
+4. Open the Local Security Policy and add the *Administrators* security group to **Security Settings** > **Local Policies** > **User Rights Assignment** > **Access this computer from the network**.
 
 To perform a management operation:
   

--- a/Teams/rooms/rooms-operations.md
+++ b/Teams/rooms/rooms-operations.md
@@ -100,7 +100,8 @@ For example, you can enable Remote PowerShell as follows:
   
 1. Sign in as Admin on a Microsoft Teams Rooms device.
 2. Open an elevated PowerShell command prompt.
-3. Enter the following command: Enable-PSRemoting -force
+3. Enter the following command: `Enable-PSRemoting -SkipNetworkProfileCheck -Force`
+4. Open the Local Security Policy and add the *Administrators* security group to *Security Settings > Local Policies > User Rights Assignment > Access this computer from the network*
 
 To perform a management operation:
   


### PR DESCRIPTION
The Microsoft Teams Rooms image runs Hyper-V, which has a hidden public network, prevent the execution of `Enable-PSRemoting`, that requires the `-SkipNetworkProfileCheck` parameter. It also has a custom security template which denies access to this computer over the network, which needs to be re-enabled.