### PR TITLE
Extra space in PowerShell command

### DIFF
--- a/Skype/SfbServer/manage/health-and-monitoring/rate-my-call.md
+++ b/Skype/SfbServer/manage/health-and-monitoring/rate-my-call.md
@@ -49,7 +49,7 @@ The Rate My Call feature is enabled by default in the Client policy with the fol
 There is no action required to enable the base feature, however but if you want custom feedback you will need to enable it separately. The following Windows PowerShell cmdlet is an example of enabling custom end user feedback and changing the interval from 10% to 80%.
 
 ```PowerShell
-Set-CSClientPolicy -Identity <PolicyIdentity> -RateMyCallDisplayPercentage 80 - RateMyCallAllowCustomUserFeedback $true 
+Set-CSClientPolicy -Identity <PolicyIdentity> -RateMyCallDisplayPercentage 80 -RateMyCallAllowCustomUserFeedback $true 
 ```
 
 ## Accessing Rate My Call Data


### PR DESCRIPTION
There is an extra space in the PowerShell command for the "RateMyCallAllowCustomUserFeedback" parameter. This will cause the command to fail.