### PR TITLE
Update setting-up-the-meeting-migration-service-mms.md

### DIFF
--- a/Skype/SfbOnline/audio-conferencing-in-office-365/setting-up-the-meeting-migration-service-mms.md
+++ b/Skype/SfbOnline/audio-conferencing-in-office-365/setting-up-the-meeting-migration-service-mms.md
@@ -59,7 +59,7 @@ From the time MMS is triggered, it typically takes about 2 hours until the userâ
 
 **Notes**:
 
-- MMS replaces everything in the online meeting information block when a meeting is migrated. Therefore, if a user has edited that block, their changes will be overwritten. Any content they have in the meeting details outside of the online meeting information block won't be affected.
+- MMS replaces everything in the online meeting information block when a meeting is migrated. Therefore, if a user has edited that block, their changes will be overwritten. Any content they have in the meeting details outside of the online meeting information block won't be affected. This means files attached to the meeting invite will remain. 
 - Only the Skype for Business or Microsoft Teams meetings that were scheduled by clicking the **Add Skype meeting** button in Outlook on the Web or by using the Skype Meeting add-in for Outlook are migrated. If a user copies and pastes the Skype online meeting information from one meeting to a new meeting, that new meeting won't be updated since there is no meeting in the original service.
 - Meeting content that was created or attached to the meeting (whiteboards, polls, and so on) won't be retained after MMS runs. If your meeting organizers have attached content to the meetings in advance, the content will need to be recreated after MMS runs.
 - The link to the shared meeting notes in the calendar item and also from within the Skype meeting also will be overwritten. Note that the actual meeting notes stored in OneNote will still be there; it is only the link to the shared notes that is overwritten.

--- a/Skype/SfbOnline/audio-conferencing-in-office-365/setting-up-the-meeting-migration-service-mms.md
+++ b/Skype/SfbOnline/audio-conferencing-in-office-365/setting-up-the-meeting-migration-service-mms.md
@@ -59,7 +59,7 @@ From the time MMS is triggered, it typically takes about 2 hours until the userâ
 
 **Notes**:
 
-- MMS replaces everything in the online meeting information block when a meeting is migrated. Therefore, if a user has edited that block, their changes will be overwritten. Any content they have in the meeting details outside of the online meeting information block won't be affected. This means files attached to the meeting invite will remain. 
+- MMS replaces everything in the online meeting information block when a meeting is migrated. Therefore, if a user has edited that block, their changes will be overwritten. Any content they have in the meeting details outside of the online meeting information block won't be affected. This means any files attached to the meeting invite will still be included. 
 - Only the Skype for Business or Microsoft Teams meetings that were scheduled by clicking the **Add Skype meeting** button in Outlook on the Web or by using the Skype Meeting add-in for Outlook are migrated. If a user copies and pastes the Skype online meeting information from one meeting to a new meeting, that new meeting won't be updated since there is no meeting in the original service.
 - Meeting content that was created or attached to the meeting (whiteboards, polls, and so on) won't be retained after MMS runs. If your meeting organizers have attached content to the meetings in advance, the content will need to be recreated after MMS runs.
 - The link to the shared meeting notes in the calendar item and also from within the Skype meeting also will be overwritten. Note that the actual meeting notes stored in OneNote will still be there; it is only the link to the shared notes that is overwritten.


### PR DESCRIPTION
**Notes**:
added one sentence to clarify files attached to an invite would remain . regards. 
- MMS replaces everything in the online meeting information block when a meeting is migrated. Therefore, if a user has edited that block, their changes will be overwritten. Any content they have in the meeting details outside of the online meeting information block won't be affected. This means files attached to the meeting invite will remain.