### PR TITLE
Update msi download links to be dynamic link

### DIFF
--- a/Teams/teams-for-vdi.md
+++ b/Teams/teams-for-vdi.md
@@ -139,8 +139,8 @@ To learn more about Teams and Microsoft 365 Apps for enterprise, see [How to exc
 1. Download the Teams MSI package that matches your VDI VM operating system using one of the following links:
 
 
-    - [32-bit version](https://statics.teams.cdn.office.net/production-windows/1.3.00.12058/Teams_windows.msi)
-    - [64-bit version](https://statics.teams.cdn.office.net/production-windows-x64/1.3.00.12058/Teams_windows_x64.msi)
+    - [32-bit version](https://teams.microsoft.com/downloads/desktopurl?env=production&plat=windows&managedInstaller=true&download=true)
+    - [64-bit version](https://teams.microsoft.com/downloads/desktopurl?env=production&plat=windows&arch=x64&managedInstaller=true&download=true)
 
 
     The minimum version of the Teams desktop app that's required is version 1.3.00.4461. (PSTN hold isn't supported in earlier versions.)


### PR DESCRIPTION
Current MSI links are a static link that points to a fixed older version of MSI. This update point the link and get the latest MSI version.