### PR TITLE
Update teams-powershell-install.md

### DIFF
--- a/Teams/teams-powershell-install.md
+++ b/Teams/teams-powershell-install.md
@@ -97,13 +97,13 @@ To start working with Teams PowerShell, sign in with your Azure credentials.
 > If you're using the latest [Teams PowerShell public preview release](https://www.powershellgallery.com/packages/MicrosoftTeams/), you don't need to install the Skype for Business Online Connector.
 
 ```powershell
-$credential = Get-Credentials
+$credential = Get-Credential
 
 #Connect to Microsoft Teams
-Connect-MicrosoftTeams -Credentials $credential
+Connect-MicrosoftTeams -Credential $credential
 
 #Connection to Skype for Business Online and import into Ps session
-$session = New-CsOnlineSession -Credentials $credential
+$session = New-CsOnlineSession -Credential $credential
 Import-PsSession $session
 ```
 


### PR DESCRIPTION
The actual parameter to Sign in of Microsoft Teams is not valid, if you use the Get-Credentials is not valid as a parameter, the correct syntax is Get-Credentials.

This script works very well, it's only change the parameter of -Credentials to -Credential
`$credential = Get-Credential

#Connect to Microsoft Teams
Connect-MicrosoftTeams -Credential $credential

#Connection to Skype for Business Online and import into Ps session
$session = New-CsOnlineSession -Credential $credential
Import-PsSession $session
`
![image](https://user-images.githubusercontent.com/20950893/87157094-4dcce780-c283-11ea-808e-aec0f5eb431d.png)
