### PR TITLE
Update meeting-settings-in-teams.md

### DIFF
--- a/Teams/meeting-settings-in-teams.md
+++ b/Teams/meeting-settings-in-teams.md
@@ -92,7 +92,7 @@ If you're using Quality of Service (QoS)to prioritize network traffic, you can e
 
     - To allow DSCP markings to be used for QoS, turn on **Insert Quality of Service (QoS) markers for real-time media traffic**. You only have the option of using markers or not; you can't set custom markers for each traffic type. See [Select a QoS implementation method](QoS-in-Teams.md#select-a-qos-implementation-method) for more on DSCP markers.
         > [!NOTE]
-        > Turning on **Insert Quality of Service (QoS) markers for real-time media traffic** will also enable communication to the Transport Relay with UDP ports 3479 (Audio), 3480 (Video) and 3481 (Sharing).
+        > DSCP tagging is typically done via Source Ports and UDP traffic will route to Transfport Relay with destination port of 3478 by default.  If your company requires tagging on destination ports, please contact support to enable communication to the Transport Relay with UDP ports 3479 (Audio), 3480 (Video) and 3481 (Sharing).
     - To specify port ranges, next to **Select a port range for each type of real-time media traffic**, select  **Specify port ranges**, and then enter the starting and ending ports for audio, video, and screen sharing. Selecting this option is required to implement QoS.
         > [!IMPORTANT]
         > If you select **Automatically use any available ports**, available ports between 1024 and 65535 are used. Use this option only when not implementing QoS.


### PR DESCRIPTION
@LanaChin @SerdarSoysal  @sonu-arora 

Updating this documentation to reflect changes made by engineering per this ICM: https://portal.microsofticm.com/imp/v3/incidents/details/195655177/home

The original plan was that enabling DSCP tagging would cause destination ports of 3479-3481 to be used for Audio, Video and Desktop Sharing but apparently this caused too many failures because of customer firewall rules and we are now sending all traffic to UDP Port 3478. However, customers can requests to have an exception made to their tenant and their tenant ID will be added to ECS list to allow port segregation. 

From IC 

Worth noting that we wanted to make it so relays always behave as customer asks. We found that we could not because it breaks a bunch of customers who have only opened 3478 in their networks. So we still have this behavior as an ECS key that we can set, if the customer really wants it. Using source ports for QoS marking is generally the better approach though.