### PR TITLE
Update dialing-out-from-a-teams-meeting-so-other-people-can-join-it.md

### DIFF
--- a/Teams/dialing-out-from-a-teams-meeting-so-other-people-can-join-it.md
+++ b/Teams/dialing-out-from-a-teams-meeting-so-other-people-can-join-it.md
@@ -33,7 +33,8 @@ When you dial out to someone, we recommend that you do so using their full phone
   Please note that:
 
 - You can dial out only if you join a meeting using Teams.
-- You, as the meeting organizer, have been enabled for audio conferencing.
+- The meeting organizer, has been enabled for audio conferencing, OR, in the case no audio conferencing license is assigned, is allowed to make calls to the public switched telephone network via online calling plans or direct routing.
+- The meeting organizer is [Granted an online dial out policy that enables dial out from conferencing enabled](https://docs.microsoft.com/en-us/powershell/module/skype/grant-csdialoutpolicy?view=skype-ps)
 
 > [!NOTE]
 > [!INCLUDE [updating-admin-interfaces](includes/updating-admin-interfaces.md)]


### PR DESCRIPTION
@tonysmit 

Can you check with Oscar on this? 1:1 PSTN call escalation and Dial out should be same logic. Certainly from testing this is how it works. This article doesn't account for this behavior and is missing information about CsOnlineDialOutPolicy. 

If a meeting organizer does not have an AudioConferencing License assigned, dial out from the meeting will follow the users normal PSTN voice route.
If a meeting organizer dos have an AudioConferncing License assigned, dial out from the meeting will be via the conferencing bridge. 

In both cases, user needs a dial out policy that enables dial out from meetings.