### PR TITLE
Update text regarding renewal behaviour

### DIFF
--- a/Teams/team-expiration-renewal.md
+++ b/Teams/team-expiration-renewal.md
@@ -27,7 +27,7 @@ When you apply an expiration policy to a team, a team owner receives a notificat
 
 ![Screenshot of the Renew Now button to renew a team in team settings](media/team-expiration.png "Screenshot of the Renew Now button to renew a team in team settings")
 
-If the team owner doesn't renew the team, the team is put in a "soft-deleted" state, which means it can be restored within the next 30 days.
+If the team owner doesn't renew the team, and there is no further activity on the team until the end of the expiration policy, the team is put in a "soft-deleted" state, which means it can be restored within the next 30 days.
 
 ## Team auto-renewal
 

--- a/Teams/team-expiration-renewal.md
+++ b/Teams/team-expiration-renewal.md
@@ -27,7 +27,7 @@ When you apply an expiration policy to a team, a team owner receives a notificat
 
 ![Screenshot of the Renew Now button to renew a team in team settings](media/team-expiration.png "Screenshot of the Renew Now button to renew a team in team settings")
 
-If the team owner doesn't renew the team, and there is no further activity on the team until the end of the expiration policy, the team is put in a "soft-deleted" state, which means it can be restored within the next 30 days.
+If the team owner doesn't renew the team and there is no further activity on the team until the end of the expiration policy, the team is put in a "soft-deleted" state, which means it can be restored within the next 30 days.
 
 ## Team auto-renewal
 


### PR DESCRIPTION
Proposed change:

If the team owner doesn't renew the team, [INSERTED] and there is no further activity on the team until the end of the expiration policy [/INSERTED], the team is put in a "soft-deleted" state, which means it can be restored within the next 30 days."

More info: 
The simple fact of the owner getting to the "renew now" button should count as activity so the team will be renewed as per our further documentation:
"If prior activity is not detected, the system will continue to watch for activity until the expiration date. If activity is detected, the system will advance the expiration date by the specified amount at that time."
https://docs.microsoft.com/en-us/microsoft-365/admin/create-groups/office-365-groups-expiration-policy?view=o365-worldwide