### PR TITLE
Adjusting PS to install Public Preview version

### DIFF
--- a/Teams/teams-powershell-install.md
+++ b/Teams/teams-powershell-install.md
@@ -69,10 +69,10 @@ If you're using PowerShell 5.1, you must update the **PowerShellGet** module bef
 Install-Module PowerShellGet -Force -AllowClobber
 ```
 
-To install Teams PowerShell public preview, run the PowerShell command below.
+To install Teams PowerShell public preview (current version is 1.1.3-preview), run the PowerShell command below.
 
 ```powershell
-Install-Module MicrosoftTeams -AllowPrerelease
+Install-Module MicrosoftTeams -AllowPrerelease -RequiredVersion 1.1.3-preview
 ```
 
 ## Install the Skype for Business Online Connector


### PR DESCRIPTION
Hello,

I am proposing to specify the Public Preview version as the current PS Line

``Install-Module MicrosoftTeams -AllowPrerelease``

**won't install the Public Preview but the GA version** and this is confusing users.

I know that hardcoding the version isn't the best, but again, the current instructions don't work as intended.

cc @brandber 