### PR TITLE
Update direct-routing-enable-users.md

### DIFF
--- a/Teams/direct-routing-enable-users.md
+++ b/Teams/direct-routing-enable-users.md
@@ -48,16 +48,30 @@ If your Skype for Business Online deployment coexists with Skype for Business 20
 
 For information about license requirements, see [licensing and other requirements](direct-routing-plan.md#licensing-and-other-requirements) in [Plan Direct Routing](direct-routing-plan.md).
 
-## Ensure that the user is homed online 
+## Ensure that the user is homed online and phone number is not being synced from on-premises (applicable for Skype for Business Server Enterprise Voice enabled users being migrated to Teams Direct Routing)
 
-Direct Routing requires the user to be homed online. You can check by looking at the RegistrarPool parameter, which needs to have a value in the infra.lync.com domain.
+Direct Routing requires the user to be homed online. You can check by looking at the RegistrarPool parameter, which needs to have a value in the infra.lync.com domain. 
+OnPremLineUriManuallySet parameter should also to be set to True. This is achieved by configuring the phone number and enable enterprise voice and voicemail using Skype for Business Online PowerShell.
 
-1. Connect to remote PowerShell.
+1. Connect a Skype for Business Online PowerShell session.
 2. Issue the command: 
 
     ```PowerShell
-    Get-CsOnlineUser -Identity "<User name>" | fl RegistrarPool
+    Get-CsOnlineUser -Identity "<User name>" | fl RegistrarPool,OnPremLineUriManuallySet,OnPremLineUri,LineUri
     ``` 
+In case OnPremLineUriManuallySet is set to False and LineUri is populated with a <E.164 phone number>, please clean the parameters using on-premises Skype for Business Management Shell, before configuring the phone number using Skype for Business Online PowerShell. 
+
+1. From Skype for Business Management Shell issue the command: 
+
+   ```PowerShell
+   Set-CsUser -Identity "<User name>" -LineUri $null -EnterpriseVoiceEnabled $False -HostedVoiceMail $False
+    ``` 
+After the changes have synced to Office 365 the expected output of Get-CsOnlineUser -Identity "<User name>" | fl RegistrarPool,OnPremLineUriManuallySet,OnPremLineUri,LineUri would be:
+
+RegistrarPool                        : pool.infra.lync.com
+OnPremLineURIManuallySet             : True
+OnPremLineURI                        : 
+LineURI                              : 
 
 ## Configure the phone number and enable enterprise voice and voicemail 
 
@@ -65,8 +79,8 @@ After you have created the user and assigned a license, the next step is to conf
 
 To add the phone number and enable for voicemail:
  
-1. Connect to a remote PowerShell session. 
-2. Enter the command: 
+1. Connect a Skype for Business Online PowerShell session. 
+2. Issue the command: 
  
     ```PowerShell
     Set-CsUser -Identity "<User name>" -EnterpriseVoiceEnabled $true -HostedVoiceMail $true -OnPremLineURI tel:<E.164 phone number>


### PR DESCRIPTION
Think it clarifies the required user configuration, for customer scenarios where users are migrated from SfB Server EV to Teams with Direct Routing. In case OnPremLineUriManuallySet is False this means phone number has been assigned using SfB Management Shell or Control Panel, forcing calls to be routed to SfB Server infra and not SfBO/Teams.
If the above is true and user is set to TeamsOnly, this means we are forcing calls to route to Teams, however the number is assigned in SfB on-premises, generating a conflicting user configuration. Below example error message seen when SfB on-premises user tries to call a TeamsOnly user with number assigned using SfB Server Management Shell:
contentType="application/sdp;call-type=audiovideo"                     responseCode="504"                     requestType="INVITE">            <diagHeader>1066;reason="Shared address space routing is disabled";cause="Possible server configuration issue";summary="Shared address space routing (hosting of users on multiple deployments) is disabled"