### PR TITLE
Identified new limit to private chat

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -60,16 +60,18 @@ Teams chat works on a Microsoft Exchange backend, so Exchange messaging limits a
 
 |Feature  | Maximum limit  |
 |---------|---------|
-|Number of people in a private chat<sup>1</sup>  | 250 |
+|Number of people in a private chat<sup>1</sup>  | 250<sup>2</sup> |
 |Number of people in a video or audio call from chat | 20 |
-|Number of file attachments<sup>2</sup>  |10     |
-|Chat size | Approximately 28 KB per post<sup>3</sup> |
+|Number of file attachments<sup>3</sup>  |10     |
+|Chat size | Approximately 28 KB per post<sup>4</sup> |
 
 <sup>1</sup> If you have more than 20 people in a chat, the following chat features are turned off: Outlook automatic replies and Teams status messages; typing indicator; video and audio calling; sharing; read receipts. The "Set Delivery Options" button (!) is also removed when private group chats contain more than 20 members.
 
-<sup>2</sup> If the number of attachments exceeds this limit, you'll see an error message.
+<sup>2</sup> Only 200 members can be added at one time to a group chat.
 
-<sup>3</sup> 28 KB is an approximate limit because it includes the message itself (text, image links, etc.), @-mentions, and reactions.
+<sup>3</sup> If the number of attachments exceeds this limit, you'll see an error message.
+
+<sup>4</sup> 28 KB is an approximate limit because it includes the message itself (text, image links, etc.), @-mentions, and reactions.
 
 ### Emailing a channel
 

--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -67,7 +67,7 @@ Teams chat works on a Microsoft Exchange backend, so Exchange messaging limits a
 
 <sup>1</sup> If you have more than 20 people in a chat, the following chat features are turned off: Outlook automatic replies and Teams status messages; typing indicator; video and audio calling; sharing; read receipts. The "Set Delivery Options" button (!) is also removed when private group chats contain more than 20 members.
 
-<sup>2</sup> Only 200 members can be added at one time to a group chat.
+<sup>2</sup> Only 200 members at a time can be added to a group chat. [See this article for more information](https://docs.microsoft.com/microsoftteams/troubleshoot/teams-administration/unable-send-message-group-chat)
 
 <sup>3</sup> If the number of attachments exceeds this limit, you'll see an error message.
 

--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -67,7 +67,7 @@ Teams chat works on a Microsoft Exchange backend, so Exchange messaging limits a
 
 <sup>1</sup> If you have more than 20 people in a chat, the following chat features are turned off: Outlook automatic replies and Teams status messages; typing indicator; video and audio calling; sharing; read receipts. The "Set Delivery Options" button (!) is also removed when private group chats contain more than 20 members.
 
-<sup>2</sup> Only 200 members at a time can be added to a group chat. [See this article for more information](https://docs.microsoft.com/microsoftteams/troubleshoot/teams-administration/unable-send-message-group-chat)
+<sup>2</sup> Only 200 members at a time can be added to a group chat. [See this article for more information](https://docs.microsoft.com/microsoftteams/troubleshoot/teams-administration/unable-send-message-group-chat).
 
 <sup>3</sup> If the number of attachments exceeds this limit, you'll see an error message.
 


### PR DESCRIPTION
Though a group chat can have up to 250 members, you can only add 200 members at one time. If you add more than 200 members at the creation of the chat you will get an error that the chat could not be sent, but this is due to the limit of adding members only 200 at a time. This was confirmed as a limitation by Teams engineering - https://portal.microsofticm.com/imp/v3/incidents/details/206239708/home.

Thanks,
Kelly