### PR TITLE
Update teams-contact-center.md

### DIFF
--- a/Teams/teams-contact-center.md
+++ b/Teams/teams-contact-center.md
@@ -22,9 +22,6 @@ appliesto:
 
 Integrating popular contact center solutions with Microsoft Teams is a common need for customers deploying Teams Calling capabilities.  This article provides an overview of how contact center solutions can be integrated with Microsoft Teams and additional information on the partner solutions participating in the Microsoft Teams Connected Contact Center Certification Program.
 
-> [!NOTE]
-> Contact Center integration capability requires Advanced Communications license. 
-
 ## What is a Contact Center integration for Microsoft Teams?
 
 Today’s contact centers provide much more than support – they act as one of the main vehicles for interaction and unfiltered feedback on a customer’s experience with a brand. Due to the breadth of channels that today’s customers prefer to engage across – phone, email, text, social – and the expanded volume of touch points associated with present day purchase processes, many organizations have realized two additional realities:
@@ -48,6 +45,7 @@ The following partners are in the process of certifying their solution for Micro
 | Anywhere365 | https://anywhere365.io/direct-routing-contact-center-for-microsoft-teams/                                      |
 | Competella | https://www.competella.com/microsoft-teams-skype-for-business                                  |
 | ComputerTalk | https://www.computer-talk.com/product/enterprise-contact-center/ice-contact-center-for-teams         |
+| ContactCenter4All | https://docs.microsoft.com/en-us/microsoftteams/teams-contact-center#connected-contact-center-for-microsoft-teams-certification-program |
 | Enghouse Interactive | http://www.enghouseteams.com/                                                       |
 | Five9 | https://www.five9.com/products/application-integration/uc-integration                                                   |
 | Genesys | https://www.genesys.com/microsoft                                                                                   |


### PR DESCRIPTION
Removed Note about requiring Advanced Communications SKU and also added ContactCenter4All to the partner list.