### PR TITLE
Update upgrade-to-Teams-on-prem-overview.md

### DIFF
--- a/Teams/upgrade-to-Teams-on-prem-overview.md
+++ b/Teams/upgrade-to-Teams-on-prem-overview.md
@@ -48,6 +48,9 @@ Before you get started, be aware that a user who has been migrated to Teams no l
  
 You manage your user's transition to Teams using the concept of [mode](migration-interop-guidance-for-teams-with-skype.md), which is a property of [TeamsUpgradePolicy](https://docs.microsoft.com/powershell/module/skype/grant-csteamsupgradepolicy?view=skype-ps). A user who has been migrated to Teams as described above is in “TeamsOnly” mode.  For an organization that is migrating to Teams, the ultimate goal is to move all users to TeamsOnly mode.
 
+>[!NOTE]
+>Users who have a Skype for Business on-premises account cannot be TeamsOnly. Although these users can [use Teams in Islands mode](migration-interop-guidance-for-teams-with-skype), this does not provide the full set of Teams functionality that is available in TeamsOnly mode. To make these users TeamsOnly, they must be moved to the cloud using `Move-CsUser` in the on-premises Skype for Business Server tools.
+
 OK. Let's get started.  The first step is understanding the [upgrade methods available to you](upgrade-to-teams-on-prem-upgrade-methods.md).
 
 


### PR DESCRIPTION
clarified that onprem users can't be TeamsOnly and that using Teams in Islands mode is not same as TeamsOnly.

btw, for the "use Teams in Islands mode" I added a link to the Migraiton-Interop-guidance-forTeams-with-skype for more details. But i think a better link would be this specific subsection on the following page:

https://docs.microsoft.com/en-us/MicrosoftTeams/upgrade-to-teams-on-prem-upgrade-methods#overlapping-capabilities-method-using-islands-mode

i wasn't sure how to link to a specific section in a page.  If you can fix that, pls do so.