### PR TITLE
Update audio-conferencing-on-network.md

### DIFF
--- a/Teams/audio-conferencing-on-network.md
+++ b/Teams/audio-conferencing-on-network.md
@@ -33,7 +33,7 @@ This article describes the prerequisites and configuration steps required to ena
 
 Before configuring On-network Conferencing, make sure your organization meets the following prerequisites: 
 
-- Ensure that all users in your organization who are enabled, or will be enabled, for Audio Conferencing are in Teams Only mode. The routing of inbound and outbound Audio Conferencing calls through On-network Conferencing is only supported for Teams meetings.
+- Ensure that all users in your organization who are enabled, or will be enabled, for Audio Conferencing are using Teams for all Meetings. The routing of inbound and outbound Audio Conferencing calls through On-network Conferencing is only supported for Teams meetings.
 
 - Assign Audio Conferencing licenses to all users who will be using On-network Conferencing.
 
@@ -135,7 +135,7 @@ Grant-CsOnlineAudioConferencingRoutingPolicy -Identity "<User Identity>" -Policy
 
 ### Configure routing on the telephony equipment of your organization
 
-On the telephony equipment of your organization, you need to ensure that the meeting dial-out calls routed through Direct Routing are routed to the intended destination.
+On the telephony equipment of your organization, you need to ensure that the meeting dial-out calls routed through Direct Routing are routed to the intended on-network destination.
 
 
 ### (Optional) Configure a dial plan


### PR DESCRIPTION
@CarolynRowe 
Updated to clarify that this feature is only supported in Teams Meetings. It does not require Teams Only client, it just requires Teams Meetings. Calls are initiated via the Online Teams Meeting service, so mode of Teams client is not relevant. 

Also added clarity that outbound calling is destined to on-network destination because its not supported to route these calls beyond corporate network to PSTN.