### PR TITLE
Fix a missing parameter in listing the latest version

### DIFF
--- a/Teams/teams-powershell-install.md
+++ b/Teams/teams-powershell-install.md
@@ -72,7 +72,7 @@ Install-Module PowerShellGet -Force -AllowClobber
 To install Teams PowerShell public preview, run the PowerShell command below.
 
 > [!NOTE]
-> You can find the latest preview version at [PowerShell Gallery](https://www.powershellgallery.com/packages/MicrosoftTeams) or in PowerShell by running "Find-Module MicrosoftTeams -AllowPrerelease"
+> You can find the latest preview version at [PowerShell Gallery](https://www.powershellgallery.com/packages/MicrosoftTeams) or in PowerShell by running "Find-Module MicrosoftTeams -AllowPrerelease -AllVersions"
 
 ```powershell
 Install-Module MicrosoftTeams -AllowPrerelease -RequiredVersion "1.1.3-preview"


### PR DESCRIPTION
Without -AllVersions, the command returns only 1.1.6 and not the wanter 1.1.5-preview.