### PR TITLE
Update reset-the-audio-conferencing-pin-in-teams.md

### DIFF
--- a/Teams/reset-the-audio-conferencing-pin-in-teams.md
+++ b/Teams/reset-the-audio-conferencing-pin-in-teams.md
@@ -50,6 +50,8 @@ Meetings can be started when an authenticated user joins using the Microsoft Tea
 1. Have the user go to [https://admin0m.online.lync.com/lscp/usp/pstnconferencing](https://admin0m.online.lync.com/lscp/usp/pstnconferencing).
 2. Click **Reset PIN**. 
 
+> [!NOTE]
+> For GCCH go to: https://webdir2g.online.gov.skypeforbusiness.us/lscp/usp/pstnconferencing.
 
 ## What else should you know about PINs?
 


### PR DESCRIPTION
added lines at 53-54 to include URL for GCCH. I do not have access to DOD but believe it is https://webdir1g.online.gov.skypeforbusiness.us/lscp/usp/pstnconferencing but no way to confirm - would be great to include DOD if we can confirm that URL