### PR TITLE
Update create-a-phone-system-auto-attendant.md

### DIFF
--- a/Teams/create-a-phone-system-auto-attendant.md
+++ b/Teams/create-a-phone-system-auto-attendant.md
@@ -196,7 +196,7 @@ When transferring calls to an external phone number, the resource account associ
 - For a resource account with a Calling Plan number, assign a [Calling Plan](calling-plans-for-office-365.md) license.
 - For a resource account with a Direct Routing number, assign an [online voice routing policy](manage-voice-routing-policies.md).
 
-When setting the destination for the External phone number:
+When setting the destination for the external phone number:
 
 - If the call will route via Calling Plan, assign a number in E.164 format including country code
 - If the call will route via Direct Routing, assign a number that will match the pattern for tenant configured voice route

--- a/Teams/create-a-phone-system-auto-attendant.md
+++ b/Teams/create-a-phone-system-auto-attendant.md
@@ -196,6 +196,11 @@ When transferring calls to an external phone number, the resource account associ
 - For a resource account with a Calling Plan number, assign a [Calling Plan](calling-plans-for-office-365.md) license.
 - For a resource account with a Direct Routing number, assign an [online voice routing policy](manage-voice-routing-policies.md).
 
+When setting the destination for the External phone number:
+
+- If the call will route via Calling Plan, assign a number in E.164 format including country code
+- If the call will route via Direct Routing, assign a number that will match the pattern for tenant configured voice route
+
 The outbound phone number that's displayed is determined as follows:
 
   - For Calling Plan numbers, the original caller's phone number is displayed.
@@ -205,7 +210,7 @@ The outbound phone number that's displayed is determined as follows:
 
 Transfers between Calling Plan trunks and Direct Routing trunks aren't supported.
 
-In a hybrid environment, to transfer an auto attendant call to the PSTN via Skype for Business PSTN integration, create a new on-premises user with call forwarding set to the PSTN number. The user must be enabled for Enterprise Voice and have a voice policy assigned. To learn more, see [Auto attendant call transfer to PSTN](https://docs.microsoft.com/SkypeForBusiness/plan/exchange-unified-messaging-online-migration-support#auto-attendant-call-transfer-to-pstn).
+In a Skype for Business hybrid environment, to transfer an auto attendant call to the PSTN, create a new on-premises user with call forwarding set to the PSTN number. The user must be enabled for Enterprise Voice and have a voice policy assigned. To learn more, see [Auto attendant call transfer to PSTN](https://docs.microsoft.com/SkypeForBusiness/plan/exchange-unified-messaging-online-migration-support#auto-attendant-call-transfer-to-pstn).
 
 ### Create an auto attendant with PowerShell
 

--- a/Teams/create-a-phone-system-auto-attendant.md
+++ b/Teams/create-a-phone-system-auto-attendant.md
@@ -199,7 +199,7 @@ When transferring calls to an external phone number, the resource account associ
 When setting the destination for the external phone number:
 
 - If the call will route via Calling Plan, assign a number in E.164 format, including country code.
-- If the call will route via Direct Routing, assign a number that will match the pattern for tenant configured voice route
+- If the call will route via Direct Routing, assign a number that will match the pattern for the tenant-configured voice route.
 
 The outbound phone number that's displayed is determined as follows:
 

--- a/Teams/create-a-phone-system-auto-attendant.md
+++ b/Teams/create-a-phone-system-auto-attendant.md
@@ -198,7 +198,7 @@ When transferring calls to an external phone number, the resource account associ
 
 When setting the destination for the external phone number:
 
-- If the call will route via Calling Plan, assign a number in E.164 format including country code
+- If the call will route via Calling Plan, assign a number in E.164 format, including country code.
 - If the call will route via Direct Routing, assign a number that will match the pattern for tenant configured voice route
 
 The outbound phone number that's displayed is determined as follows:


### PR DESCRIPTION
@MikePlumleyMSFT 
PM for this is naveenv@microsoft.com 

Added information about how to configure the destination number because we have cases on this coming in. Found this in TAP and had requested UI warning to prevent customer errors. 

Also revised wording for the Skype for Business Hybrid to make it clearer. Customers and support engineers were not clear on this point. If a tenant is Skype for Business Hybrid and Skype users on premise will call AA, then routing will fail if External Phone number is used for routing to PSTN. In this case customers needs to use a target of a user that is on-premises EV enabled with forwarding to PSTN.