### PR TITLE
Add Set-CsTenantPublicProvider to Using PowerShell

### DIFF
--- a/Teams/teams-skype-interop.md
+++ b/Teams/teams-skype-interop.md
@@ -6,11 +6,11 @@ manager: serdars
 ms.topic: article
 ms.service: msteams
 audience: admin
-ms.collection: 
+ms.collection:
   - M365-collaboration
 ms.reviewer: vinbel
 search.appverid: MET150
-description: Learn about the interoperability capabilities between Teams users in your organization and Skype (Consumer) users. 
+description: Learn about the interoperability capabilities between Teams users in your organization and Skype (Consumer) users.
 localization_priority: Normal
 ---
 
@@ -79,6 +79,8 @@ In the Microsoft Teams admin center, go to **Org-wide settings** > **External ac
 ### Using PowerShell
 
 Use the [Set-CsExternalAccessPolicy](https://docs.microsoft.com/powershell/module/skype/set-csexternalaccesspolicy) cmdlet together with the ```EnablePublicCloudAccess``` parameter to control whether Teams users can communicate with Skype users. Setting the parameter to ```true``` allows Teams users to communicate with Skype users. You can use the ```EnablePublicCloudAudioVideoAccess``` parameter to enable/disable audio/video calls.
+
+Use the [Set-CsTenantPublicProvider](https://docs.microsoft.com/powershell/module/skype/Set-CsTenantPublicProvider) cmdlet together with the ```Provider``` parameter set to ```"WindowsLive"``` so that Teams users can communicate with Skype users
 
 ## Related topics
 

--- a/Teams/teams-skype-interop.md
+++ b/Teams/teams-skype-interop.md
@@ -78,9 +78,10 @@ In the Microsoft Teams admin center, go to **Org-wide settings** > **External ac
 
 ### Using PowerShell
 
-Use the [Set-CsExternalAccessPolicy](https://docs.microsoft.com/powershell/module/skype/set-csexternalaccesspolicy) cmdlet together with the ```EnablePublicCloudAccess``` parameter to control whether Teams users can communicate with Skype users. Setting the parameter to ```true``` allows Teams users to communicate with Skype users. You can use the ```EnablePublicCloudAudioVideoAccess``` parameter to enable/disable audio/video calls.
+Do the following: 
+1. Use the [Set-CsExternalAccessPolicy](https://docs.microsoft.com/powershell/module/skype/set-csexternalaccesspolicy) cmdlet together with the ```EnablePublicCloudAccess``` parameter to control whether Teams users can communicate with Skype users. Setting the parameter to ```true``` allows Teams users to communicate with Skype users. You can use the ```EnablePublicCloudAudioVideoAccess``` parameter to enable/disable audio/video calls.
 
-Use the [Set-CsTenantPublicProvider](https://docs.microsoft.com/powershell/module/skype/Set-CsTenantPublicProvider) cmdlet together with the ```Provider``` parameter set to ```"WindowsLive"``` so that Teams users can communicate with Skype users
+2. Use the [Set-CsTenantPublicProvider](https://docs.microsoft.com/powershell/module/skype/Set-CsTenantPublicProvider) cmdlet together with the ```Provider``` parameter set to ```"WindowsLive"``` so that Teams users can communicate with Skype users.
 
 ## Related topics
 


### PR DESCRIPTION
To full enable Skype Consumer Interop, Set-CsTenantPublicProvider -Provider "WindowsLive" must also be run