### PR TITLE
Update the limitation of Meeting Notes tab

### DIFF
--- a/Teams/meeting-policies-in-teams.md
+++ b/Teams/meeting-policies-in-teams.md
@@ -408,7 +408,7 @@ Amanda can't share the whiteboard in a meeting even if she's the meeting organiz
 
 ### Allow shared notes
 
-This is a per-user policy. This setting controls whether a user can create and share notes in a meeting. External users, including anonymous, B2B, and federated users, inherit the policy of the meeting organizer. The **Meeting Notes** tab is currently only supported in meetings that have fewer than 20 participants.
+This is a per-user policy. This setting controls whether a user can create and share notes in a meeting. External users, including anonymous, B2B, and federated users, inherit the policy of the meeting organizer. The **Meeting Notes** tab is currently only supported in meetings that have fewer than 100 participants.
 
 Let's look at the following example.
 


### PR DESCRIPTION
Updating the limitation of Meeting Notes tab from 20 to 100.
I believe this is increased recently.
https://support.microsoft.com/en-us/office/3eadf032-0ef8-4d60-9e21-0691d317d103