### PR TITLE
Fixed typos in export-teams-content.md

### DIFF
--- a/Teams/export-teams-content.md
+++ b/Teams/export-teams-content.md
@@ -89,13 +89,13 @@ Namespace: microsoft.graph
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "id": "0de69e5e-2da8-4cf2-821f-5e6585b2c65b",
-                    "displayName": "User Name",
+                    "id": "string (identifier)",
+                    "displayName": "string",
                     "userIdentityType": "aadUser"                }
             },
 "body": {"@odata.type": "microsoft.graph.itemBody"},
 "summary": "string",
-"chatId": "19:0de69e5e-2da8-4cf2-821f-5e6585b2c65b_5c64e248-3269-4268-a36e-0f80314e9c39@unq.gbl.spaces"
+"chatId": "string (identifier)"
 "attachments": \[{"@odata.type": "microsoft.graph.chatMessageAttachment"}\],
 "mentions": \[{"@odata.type": "microsoft.graph.chatMessageMention"}\],
 "importance": "string",


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/5914.