### PR TITLE
Fixing Debian based Linux install

### DIFF
--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -121,7 +121,7 @@ The signing key to enable auto-updating using the system's package manager is in
 1. Download the package from https://aka.ms/getteams.
 2. Install using one of the following:  
     - Open the relevant package management tool and go through the self-guided Linux app installation process.
-    - Or if you love Terminal, type: `sudo apt install **teams download file**`
+    - Or if you love Terminal, type: `sudo dpkg -i **teams download file**`
 
 You can launch Teams via Activities or via Terminal by typing `teams`. 
 


### PR DESCRIPTION
sudo apt install is not the correct way to install a deb file, use sudo dpkg -i instead