### PR TITLE
Added W2012R2 support to hardware-requirements-for-the-teams-app.md

### DIFF
--- a/Teams/hardware-requirements-for-the-teams-app.md
+++ b/Teams/hardware-requirements-for-the-teams-app.md
@@ -35,7 +35,7 @@ All of the requirements in the following sections apply to both the Microsoft Te
 |Hard disk    | 3.0 GB of available disk space        |
 |Display    |   1024 x 768 screen resolution |
 |Graphics hardware |  Windows OS: Graphics hardware acceleration requires DirectX 9 or later, with WDDM 2.0 or higher for Windows 10 (or WDDM 1.3 or higher for Windows 10 Fall Creators Update)
-|Operating system  |    Windows 10, Windows 10 on ARM, Windows 8.1, Windows Server 2019, Windows Server 2016|
+|Operating system  |    Windows 10, Windows 10 on ARM, Windows 8.1, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2|
 |.NET version    |  Requires .NET 4.5 CLR or later       |
 |Video    |  USB 2.0 video camera       |
 |Devices    |   Standard laptop camera, microphone, and speakers    |


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/6315.

@cichur, you added W2016 or latter support here:
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/commit/65d9676d3bdf29a0b07447db863a56b2ea941531

 @voltarone you added W2012R2 or later support here:
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/commit/dc29b311736b959b0f991a6ba58274d54f40fada

Could you kindly help me to confirm which is the oldest version supported? Thanks!
