### PR TITLE
Update limits-specifications-teams.md

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -219,7 +219,7 @@ A class team can support more than 200 members. However, if you plan to use eith
 |Number of tags per team    | 100        |
 |Number of suggested default tags per team    | 25        |
 |Number of team members assign to a tag    |100         |
-|Number of tags assigned to a user    |25         |
+|Number of tags assigned to a user per team    |25         |
 
 ## Contacts
 


### PR DESCRIPTION
The max tags per user of 25 is at a per team level. For example, I can have 24 tags in Team A and 20 tags in Team B and that is OK. I cannot have 30 tags in Team A. 