### PR TITLE
Adding en-us to the URL for this blog post "The top nine ways Microso…

### DIFF
--- a/Teams/support-remote-work-with-teams.md
+++ b/Teams/support-remote-work-with-teams.md
@@ -69,7 +69,7 @@ Share these assets and videos with your end users to help them get started quick
    - [How Microsoft is enabling its employees to work remotely with Microsoft Teams](https://www.microsoft.com/itshowcase/blog/how-microsoft-enables-its-employees-to-work-remotely/)
    - [Helping small and medium-sized businesses work remotely with Teams](https://www.microsoft.com/microsoft-365/blog/2020/03/17/helping-smb-customers-work-remotely-microsoft-teams/)
 
-   - [The top nine ways Microsoft IT is enabling remote work for its employees](https://www.microsoft.com/microsoft-365/blog/2020/03/12/top-9-ways-microsoft-it-enabling-remote-work-employees/)
+   - [The top nine ways Microsoft IT is enabling remote work for its employees](https://www.microsoft.com/en-us/microsoft-365/blog/2020/03/12/top-9-ways-microsoft-it-enabling-remote-work-employees/)
 
 
 1. Teams for Education 


### PR DESCRIPTION
…ft IT is enabling remote work for its employee"

This blog post is not localized (the one before it is) and customers are reporting that it's incorrectly adding ll-cc to links from the localize pages e.g. https://www.microsoft.com/de-de/microsoft-365/blog/2020/03/12/top-9-ways-microsoft-it-enabling-remote-work-employees/ which results in 404.