### PR TITLE
Updated guest watch permissions table in plan-for-teams-live-events.md

### DIFF
--- a/Teams/teams-live-events/plan-for-teams-live-events.md
+++ b/Teams/teams-live-events/plan-for-teams-live-events.md
@@ -86,12 +86,12 @@ As a best practice, we recommend that you create a channel for producers and pre
 | Attendee visibility | Teams production | External app or device production |
 |------------------------------|-----------------|----------------------|
 |Public (anonymous users)      |  Yes            |  No                  |
-|Guest users                   |  Yes            |  No                  |
+|Guest users                   |  Yes<sup>1</sup>            |  No                  |
 |Everyone in external access (federation) company |  Yes<sup>1</sup>|  No                  |
 |Everyone in company           |  Yes            |  Yes                 |
 |Specific groups / people      |  Yes            |  Yes                 |
 
-<sup>1</sup> External access (federation) attendees can only be invited through People & Group <br>
+<sup>1</sup> Can only be invited through People & Group <br>
 
 ## Teams live events and Skype Meeting Broadcast
 


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/6384.

@cichur @ashwinma14 could you kindly help me to confirm this information?

Guest users can also join live events only through the People & Group option. They cannot access Org-wide live events. They get "This event is in Contoso. To join, you'll need to be in that org, too."

@LanaChin added the superscript "Can watch live events if the live event is set up using the **Org-wide** option" here:
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/commit/3eeddf9608d9c2d2116fb521f3efd42d9bc9950e

But then @ashwinma14 removed it here:
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/commit/cb8f76da1c340f2c5486442fe3f7f1d0ca4a4184#diff-337ceb7fb7ab197d05f50e687463d6951a12999b4a81e6f6930185f2ccfbf5b0

Thanks!