### PR TITLE
Updating doc

### DIFF
--- a/Teams/teams-scoped-directory-search.md
+++ b/Teams/teams-scoped-directory-search.md
@@ -41,7 +41,7 @@ Scenarios that benefit from scoped directory searches are similar to address boo
 To learn how to use address book policies, read [Information Barrier policies in Exchange Online](https://docs.microsoft.com/microsoft-365/compliance/information-barriers).
 
 > [!IMPORTANT]
-> Address book policies provide only a virtual separation of users from directory perspective. Users can still initiate communications with others by providing complete email addresses. It is also important to note that any user data that had already been cached, prior to the enforcement of new or updated address book policies, will remain available to users for up to 30 days.
+> Address book policies provide only a virtual separation of users from directory perspective. It is also important to note that any user data that had already been cached, prior to the enforcement of new or updated address book policies, will remain available to users for up to 30 days.
 
 ## Turn on scoped directory search
 


### PR DESCRIPTION
Customer reported ICM https://portal.microsofticm.com/imp/v3/incidents/details/207682266/home per which the document said that a conversation can happen between two users blocked by an IB policy using a complete email address. This is not true therefore, remove the line that was saying so. Conversation between two IB blocked individuals cannot be initiated.