### PR TITLE
Update manage-emergency-calling-policies.md

### DIFF
--- a/Teams/manage-emergency-calling-policies.md
+++ b/Teams/manage-emergency-calling-policies.md
@@ -41,9 +41,9 @@ If you assigned an emergency calling policy to a network site and to a user and 
 3. Enter a name and description for the policy.
 4. Set how you want to notify people in your organization, typically the security desk, when an emergency call is made. To do this, under **Notification mode**, select one of the following:
     - **Send notification only**: A Teams chat message is sent to the users and groups that you specify.
-    - **Conferenced in but are muted**: A Teams chat message is sent to the users and groups that you specify and they can listen (but not participate) in the conversation between the caller and the PSAP operator.
-    - **Conferenced in and are unmuted** **(coming soon)**: A Teams chat message is sent to the users and groups that you specify and they can unmute to listen and participate in the conversation between the caller and the PSAP operator.
-5.  If you selected the **Conferenced in but are muted** notification mode, in the **Numbers to dial for emergency calls notifications** box, you can enter a PSTN phone number of a user or group to call and join the emergency call. For example, enter the number of your organization's security desk, who will receive a call when an emergency call is made and can then listen in on the call.
+    - **Conferenced in muted and unable to unmute**: A Teams chat message is sent to the users and groups that you specify and they can listen (but not participate) in the conversation between the caller and the PSAP operator.
+    - **Conferenced in muted but are able to unmute**: A Teams chat message is sent to the users and groups that you specify and they can unmute to listen and participate in the conversation between the caller and the PSAP operator.
+5.  If you selected either of the **Conference in muted** notification modes, in the **Numbers to dial for emergency calls notifications** box, you can enter a PSTN phone number of a user or group to call and join the emergency call. For example, enter the number of your organization's security desk, who will receive a call when an emergency call is made and can then listen in on the call. The PSTN phone cannot be unmuted even when the mode is set to **Conferenced in muted but are able to unmute**.
 6. Search for and select one or more users or groups, such as your organization's security desk, to notify when an emergency call is made.  The notification can be sent to email addresses of users, distribution groups, and security groups. A maximum of 50 users can be notified.
 7. Click **Apply**.
 


### PR DESCRIPTION
Added clarity in step 4 - disambiguate that in unmute mode the default is muted and user can unmute; also that the feature is released.

Step 5 - clarity that the phone can never unmute even when the mode is set to being able to unmute for Teams clients.