### PR TITLE
Update instructions for reporting label upload

### DIFF
--- a/Teams/learn-more-about-site-upload.md
+++ b/Teams/learn-more-about-site-upload.md
@@ -37,8 +37,8 @@ The report labels and locations data you provide is a single data structure – 
 **To edit the table of subnets and locations**
 
 1. In the left navigation of the Microsoft Teams admin center, click **Locations** > **Reporting labels**.
-2. Click **Replace locations data**.
-3. In the **Replace locations data** pane, click **Select a file**, and then browse to and upload your edited .csv or .tsv file.
+2. Click **Upload data**.
+3. In the **Upload data** pane, click **Select a file**, and then browse to and upload your edited .csv or .tsv file.
 4. Click **Upload**.
 
 You can download a sample template [here](https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/blob/live/Teams/downloads/locations-template.zip?raw=true).


### PR DESCRIPTION
The Teams Admin Center UI changed the text used in the flow for uploading reporting labels. Update the docs to match.