### PR TITLE
Update cloud-recording.md

### DIFF
--- a/Teams/cloud-recording.md
+++ b/Teams/cloud-recording.md
@@ -115,6 +115,7 @@ To enable recordings in-region in the Global policy, use the following cmdlet:
 
 ```powershell
 Set-CsTeamsMeetingPolicy -Identity Global -AllowCloudRecording $true -AllowRecordingStorageOutsideRegion $true
+```
 
 Here's a summary of what happens when you turn on meeting recording when this change takes effect:
 


### PR DESCRIPTION
Missed closing the powershell markdown tag for -AllowRecordingStorageOutsideRegion
please fix fast Meeting Recording is the #1 support call driver in Teams by a factor of 3 - this document needs to be correct