### PR TITLE
Wrong info

### DIFF
--- a/Teams/teams-and-skypeforbusiness-coexistence-and-interoperability.md
+++ b/Teams/teams-and-skypeforbusiness-coexistence-and-interoperability.md
@@ -91,7 +91,7 @@ Organizations with a starting point of Skype for Business Server on premises or 
 
 Use this coexistence mode to accelerate the availability of Teams meeting capabilities in your organization, in addition to its collaboration capabilities, enabling your users to take advantage of the superior Teams meetings experience-great quality, innovative capabilities such as transcription and translation or background blurring, and superior user experience across all platforms, including mobile devices and browsers.
 
-Along with using Teams for teams and channels–based conversations in this mode, users will use Teams to schedule and conduct their meetings. Private chat and calling remain on Skype for Business. Teams and Skype for Business benefit from a range of "better together" capabilities, such as presence reconciliation, automatic hold/unhold, and HID device support across both applications. Note that it is possible to hide teams and channels if desired using the App Permissions policy.
+Along with using Teams for teams and channels–based conversations in this mode, users will use Teams to schedule and conduct their meetings. Private chat and calling remain on Skype for Business. Teams and Skype for Business benefit from a range of "better together" capabilities, such as presence reconciliation, automatic hold/unhold, and HID device support across both applications. Note that it is possible to hide teams and channels if desired using the App Setup policy.
 
 This coexistence mode is especially useful for organizations with Skype for Business on-premises deployments with Enterprise Voice, who are likely to take some time to upgrade to Teams and want to benefit from the superior Teams meetings as soon as possible.
 


### PR DESCRIPTION
In this section, `Skype for Business with Teams Collaboration and Meetings`
**At line 94:** "Note that it is possible to hide teams and channels if desired using the App Permissions policy". 
It should be `"using the App Setup policy"`, **NOT** `"using the App Permission Policy"`