### PR TITLE
Update plan-auto-attendant-call-queue.md

### DIFF
--- a/Teams/plan-auto-attendant-call-queue.md
+++ b/Teams/plan-auto-attendant-call-queue.md
@@ -82,6 +82,9 @@ When transferring calls to an external phone number, the resource account perfor
 - An [online voice routing policy](manage-voice-routing-policies.md)
 
 > [!NOTE]
+> In a Hybrid scenario, the resource account needs to be created on-premises. For more information, see [Plan Could call queues](https://docs.microsoft.com/en-us/skypeforbusiness/hybrid/plan-call-queue)
+
+> [!NOTE]
 > Direct Routing service numbers for auto attendant and call queues are supported for Microsoft Teams users and call agents only.<br>
 > Transfers between Calling Plan trunks and Direct Routing trunks aren't supported.
 

--- a/Teams/plan-auto-attendant-call-queue.md
+++ b/Teams/plan-auto-attendant-call-queue.md
@@ -82,11 +82,9 @@ When transferring calls to an external phone number, the resource account perfor
 - An [online voice routing policy](manage-voice-routing-policies.md)
 
 > [!NOTE]
-> In a Hybrid scenario, the resource account needs to be created on-premises. For more information, see [Plan Could call queues](https://docs.microsoft.com/en-us/skypeforbusiness/hybrid/plan-call-queue)
-
-> [!NOTE]
 > Direct Routing service numbers for auto attendant and call queues are supported for Microsoft Teams users and call agents only.<br>
-> Transfers between Calling Plan trunks and Direct Routing trunks aren't supported.
+> Transfers between Calling Plan trunks and Direct Routing trunks aren't supported.<br>
+> In a Hybrid scenario, the resource account must be created on-premises. For more information, see [Plan Cloud call queues](https://docs.microsoft.com/skypeforbusiness/hybrid/plan-call-queue).
 
 ## Business decisions
 


### PR DESCRIPTION
This public documentation does not have any reference to Hybrid scenarios, this only describes the steps that should be followed for Microsoft Teams, even though at the beginning of the page it's mentioned: "Applies to: Skype for Business, Microsoft Teams"

Customer requested to be added a reference in this article where it is stated that the resource account in hybrid scenario needs to be created on-premises, and a reference to this article as well: https://docs.microsoft.com/en-us/skypeforbusiness/hybrid/plan-call-queue