### PR TITLE
Update audio-conferencing-with-direct-routing-for-gcch-and-dod.md

### DIFF
--- a/Teams/audio-conferencing-with-direct-routing-for-gcch-and-dod.md
+++ b/Teams/audio-conferencing-with-direct-routing-for-gcch-and-dod.md
@@ -41,7 +41,7 @@ To use Audio Conferencing in GCC High or DoD, your organization and the users in
 A tenant license and at least one user license are required to enable the service. You can't enable the service with only the tenant license or with only user licenses. To get service licenses for your tenant and the users in your organization, contact your account team.
 
 > [!IMPORTANT]
-> Users can't be enabled for Audio Conferencing with Direct Routing until dial-in phone numbers are set up and users have a workind dial pad in their Teams client. We recommend that you not assign Audio Conferencing with Direct Routing for GCC High or DoD licenses to users until you set up dial-in phone numbers as outlined in this article.
+> Users can't be enabled for Audio Conferencing with Direct Routing until dial-in phone numbers are set up and users have a working dial pad in their Teams client. We recommend that you not assign Audio Conferencing with Direct Routing for GCC High or DoD licenses to users until you set up dial-in phone numbers as outlined in this article.
 
 ### Step 2: Set up Direct Routing
 

--- a/Teams/audio-conferencing-with-direct-routing-for-gcch-and-dod.md
+++ b/Teams/audio-conferencing-with-direct-routing-for-gcch-and-dod.md
@@ -41,7 +41,7 @@ To use Audio Conferencing in GCC High or DoD, your organization and the users in
 A tenant license and at least one user license are required to enable the service. You can't enable the service with only the tenant license or with only user licenses. To get service licenses for your tenant and the users in your organization, contact your account team.
 
 > [!IMPORTANT]
-> Users can't be enabled for Audio Conferencing with Direct Routing until dial-in phone numbers are set up. We recommend that you not assign Audio Conferencing with Direct Routing for GCC High or DoD licenses to users until you set up dial-in phone numbers as outlined in this article.
+> Users can't be enabled for Audio Conferencing with Direct Routing until dial-in phone numbers are set up and users have a workind dial pad in their Teams client. We recommend that you not assign Audio Conferencing with Direct Routing for GCC High or DoD licenses to users until you set up dial-in phone numbers as outlined in this article.
 
 ### Step 2: Set up Direct Routing
 


### PR DESCRIPTION
At line 44 added "and users have a working dial pad in their Teams client" to clarify that we need to be sure no provisioning issues with user before AC should be enabled.  See ICM 221800930