### PR TITLE
Update direct-routing-plan.md

### DIFF
--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -95,7 +95,7 @@ Users of Direct Routing must have the following licenses assigned in Microsoft 3
 > Skype for Business Plan should not be removed from any licensing agreement where it is included. 
 > 
 > [!IMPORTANT]
-> GCC High or DoD customers should disable any Audio Conferecning licensing included in G5 and wait to enable any Audio Conferencing for their users until Direct Routing has been fully configured.  Users should have dial-in phone numbers configured and a working dial pad before enabling Audio Conferencing licenses. See also: https://docs.microsoft.com/en-us/microsoftteams/audio-conferencing-with-direct-routing-for-gcch-and-dod
+> GCC High and DoD users should disable any Audio Conferencing licensing included in G5 and wait to enable any Audio Conferencing until Direct Routing has been fully configured. Users should have dial-in phone numbers configured and a working dial pad before enabling Audio Conferencing licenses. See [Audio Conferencing with Direct Routing for GCC High and DoD](https://docs.microsoft.com/microsoftteams/audio-conferencing-with-direct-routing-for-gcch-and-dod) for more details.
 
 
 > [!IMPORTANT]

--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -93,6 +93,9 @@ Users of Direct Routing must have the following licenses assigned in Microsoft 3
 
 > [!NOTE]
 > Skype for Business Plan should not be removed from any licensing agreement where it is included. 
+> 
+> [!IMPORTANT]
+> GCC High or DoD customers should disable any Audio Conferecning licensing included in G5 and wait to enable any Audio Conferencing for their users until Direct Routing has been fully configured.  Users should have dial-in phone numbers configured and a working dial pad before enabling Audio Conferencing licenses. See also: https://docs.microsoft.com/en-us/microsoftteams/audio-conferencing-with-direct-routing-for-gcch-and-dod
 
 
 > [!IMPORTANT]


### PR DESCRIPTION
Added Important note at line 97-98 to be sure AC licenses are disabled for GCCH/DOD customers until user provisioning has completed and they have a working dial pad per ICM 221800930