### PR TITLE
Update teams-panels.md

### DIFF
--- a/Teams/devices/teams-panels.md
+++ b/Teams/devices/teams-panels.md
@@ -102,7 +102,7 @@ Planning for configuration and deployment covers the following key areas:
 
 Every Teams panels device requires a Microsoft 365 room resource account. You use the resource account credentials to sign in to Microsoft Teams app on the panels device.
 
-To set up a Microsoft 365 resource account for Teams panels, it is receommended that you purchase a [Microsoft Teams Rooms Standard license](#license-requirement). 
+To set up a Microsoft 365 resource account for Teams panels, we recommended that you purchase a [Microsoft Teams Rooms Standard license](#license-requirement). 
 For information on how to create a resource account and assign a license to it, see [Create a resource account using the Microsoft 365 admin center](resource-account-ui.md).
 
 > [!NOTE]

--- a/Teams/devices/teams-panels.md
+++ b/Teams/devices/teams-panels.md
@@ -87,7 +87,7 @@ Our recommendations for Teams panels sites are:
 
 - Dedicated resource accounts
 - Power supply (Panels generally support Power over ethernet plus (PoE+) for power. Refer to the OEM documentation for any device-specific power requirements.)
-- Quality of Service (QoS) enabled on the network for Microsoft Teams
+
 
 For physical installation considerations, see the OEM documentation and, if you have one, use the experience of your audio-visual team before you install and mount devices and run cabling.
 
@@ -102,15 +102,14 @@ Planning for configuration and deployment covers the following key areas:
 
 Every Teams panels device requires a Microsoft 365 room resource account. You use the resource account credentials to sign in to Microsoft Teams app on the panels device.
 
-To set up a Microsoft 365 resource account for Teams panels, you'll need to purchase a [Microsoft Teams Rooms Standard license](#license-requirement). This license includes a resource mailbox that enables people in your organization to book the meeting space via Outlook or Teams.
-
+To set up a Microsoft 365 resource account for Teams panels, it is receommended that you purchase a [Microsoft Teams Rooms Standard license](#license-requirement). 
 For information on how to create a resource account and assign a license to it, see [Create a resource account using the Microsoft 365 admin center](resource-account-ui.md).
 
 > [!NOTE]
 >
 >- If you already have a room resource account set up for the meeting space where you're installing panels, use the same room resource account to sign in to the panels device. However, make sure that the room resource account has the Microsoft Teams Rooms Standard license assigned to it in order to use it as panels resource account.
 >
->- If you already have a Microsoft Teams Rooms deployed in the meeting space where you're installing Teams panels, then the resource account already has the [Microsoft Teams Rooms license](../rooms/rooms-licensing.md). In such cases, you don't need to purchase a separate Microsoft Teams Rooms Standard license for deploying panels. The admin signs in to the panels device with the same credentials as the Microsoft Teams Rooms for the same space.
+>- If you already have a Microsoft Teams Rooms deployed in the meeting space where you're installing Teams panels, you don't need to purchase a separate license for deploying panels. The admin signs in to the panels device with the same credentials as the Microsoft Teams Rooms for the same space.
 >
 >- For large meeting spaces, such as board rooms or conference rooms, with multiple entrances, you can mount one panels device at each entrance. Multiple panels that belong to a single meeting space share the same resource account and sign in with the same credentials. You don't need to create separate resource accounts for each panels for the same space.
 


### PR DESCRIPTION
I'm all for QoS applied to all Teams networks. However, stating that QoS is a preferred Site readiness requirement implies that Teams Panels send media. At the current release level, they do not - and may not ever. QoS is not needed for AD sign in, EWS lookups, etc.

You can sign in to a Teams panel without a Teams Rooms Standard license. I just tested with an E5. Therefore, it appears we are making an incorrect assumption that the Teams Rooms Standard license will necessarily be assigned to the resource account.

Many organizations apply extra E3 licenses or whatever to resource accounts as they have extras and don't want to buy more licenses. And you can use the panel without a Teams rooms Standard license. So we should strongly encourage the Teams Rooms license but (at least as of right now) that license is not a requirement for a panel to work.

Teams Rooms standard does *not* include a resource account license. Resource accounts licenses are free and as such do not require a license. 

As for the Naming Convention tip.....in most cases, the resource account will already be set up using a different naming convention, e.g. "CR-Aetna" for conference room Aetna. I believe in most cases, a resource account will not be made for the Panel as it will already exist, even in a non-Teams environment. As such, the tip, while useful, can be confusing. 

This is all new and I could be wrong on all of this :) I'm still learning but this is my feedback on the article. Hope I'm not coming off snarky or anything. I truly appreciate that this article is out there and have already shared it on social media to help raise awareness.