### PR TITLE
arranged in english alphabetical order in datewise

### DIFF
--- a/Teams/includes/teams-content-updates.md
+++ b/Teams/includes/teams-content-updates.md
@@ -1,5 +1,6 @@
 <!-- This file is generated automatically each week. Changes made to this file will be overwritten.-->
-
+
+
 
 
 ## Week of February 15, 2021
@@ -9,21 +10,21 @@
 |------|------------|--------|
 | 2/16/2021 | [Call park and retrieve in Microsoft Teams](/MicrosoftTeams/call-park-and-retrieve) | modified |
 | 2/16/2021 | [Create a team using Teams healthcare templates](/MicrosoftTeams/expand-teams-across-your-org/healthcare/healthcare-templates-admin-console) | modified |
-| 2/16/2021 | [Templates for healthcare organizations](/MicrosoftTeams/expand-teams-across-your-org/healthcare/healthcare-templates) | modified |
 | 2/16/2021 | [Interoperability between Skype for Business and Microsoft Teams](/MicrosoftTeams/teams-and-skypeforbusiness-coexistence-and-interoperability) | modified |
+| 2/16/2021 | [Templates for healthcare organizations](/MicrosoftTeams/expand-teams-across-your-org/healthcare/healthcare-templates) | modified |
+| 2/17/2021 | [Call park and retrieve in Microsoft Teams](/MicrosoftTeams/call-park-and-retrieve) | modified |
+| 2/17/2021 | [Connect your Session Border Controller (SBC) to Direct Routing](/MicrosoftTeams/direct-routing-connect-the-sbc) | modified |
+| 2/17/2021 | [Install, manage, and assign permissions for the Teams Learning app (private preview)](/MicrosoftTeams/teams-learning-app-overview) | modified |
+| 2/17/2021 | [Phone System Direct Routing](/MicrosoftTeams/direct-routing-protocols-sip) | modified |
+| 2/17/2021 | [Plan for live events in Microsoft Teams](/MicrosoftTeams/teams-live-events/plan-for-teams-live-events) | modified |
+| 2/17/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
+| 2/17/2021 | [Teams apps behavior for non-standard users](/MicrosoftTeams/non-standard-users) | modified |
 | 2/17/2021 | [Teams for Remote Desktop](/MicrosoftTeams/teams-for-rdp) | added |
+| 2/17/2021 | Teams for Remote Desktop | removed |
+| 2/17/2021 | Templates for healthcare organizations | removed |
+| 2/17/2021 | [Use OneDrive for Business and SharePoint for meeting recordings](/MicrosoftTeams/tmr-meeting-recording-change) | modified |
 | 2/17/2021 | [Use Teams with remote desktop services](/MicrosoftTeams/teams-on-rdp) | added |
 | 2/17/2021 | [Use the Microsoft Teams Meeting add-in in Outlook](/MicrosoftTeams/teams-add-in-for-outlook) | modified |
-| 2/17/2021 | [Call park and retrieve in Microsoft Teams](/MicrosoftTeams/call-park-and-retrieve) | modified |
-| 2/17/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
-| 2/17/2021 | [Connect your Session Border Controller (SBC) to Direct Routing](/MicrosoftTeams/direct-routing-connect-the-sbc) | modified |
-| 2/17/2021 | [Phone System Direct Routing](/MicrosoftTeams/direct-routing-protocols-sip) | modified |
-| 2/17/2021 | Templates for healthcare organizations | removed |
-| 2/17/2021 | [Teams apps behavior for non-standard users](/MicrosoftTeams/non-standard-users) | modified |
-| 2/17/2021 | [Plan for live events in Microsoft Teams](/MicrosoftTeams/teams-live-events/plan-for-teams-live-events) | modified |
-| 2/17/2021 | [Use OneDrive for Business and SharePoint for meeting recordings](/MicrosoftTeams/tmr-meeting-recording-change) | modified |
-| 2/17/2021 | Teams for Remote Desktop | removed |
-| 2/17/2021 | [Install, manage, and assign permissions for the Teams Learning app (private preview)](/MicrosoftTeams/teams-learning-app-overview) | modified |
 
 
 ## Week of February 08, 2021
@@ -31,46 +32,45 @@
 
 | Published On |Topic title | Change |
 |------|------------|--------|
-| 2/8/2021 | [Manage user access to Education Insights](/MicrosoftTeams/education-insights-manage-access) | added |
-| 2/8/2021 | [IT Admin Guide to Education Insights in Microsoft Teams](/MicrosoftTeams/class-insights) | modified |
 | 2/8/2021 | [Call and chat with users from other organizations](/MicrosoftTeams/communicate-with-users-from-other-organizations) | modified |
 | 2/8/2021 | [Create a call queue in Microsoft Teams](/MicrosoftTeams/create-a-phone-system-call-queue) | modified |
-| 2/8/2021 | [Sync Student Information System (SIS) data with Education Insights](/MicrosoftTeams/education-insights-sis-data-sync) | modified |
+| 2/8/2021 | [IT Admin Guide to Education Insights in Microsoft Teams](/MicrosoftTeams/class-insights) | modified |
 | 2/8/2021 | [Limits and specifications for Microsoft Teams](/MicrosoftTeams/limits-specifications-teams) | modified |
-| 2/8/2021 | [Manage tags in Microsoft Teams](/MicrosoftTeams/manage-tags) | modified |
-| 2/8/2021 | [Use the Teams App Submission API to submit and approve your custom apps](/MicrosoftTeams/submit-approve-custom-apps) | modified |
 | 2/8/2021 | [Manage app setup policies in Microsoft Teams](/MicrosoftTeams/teams-app-setup-policies) | modified |
-| 2/8/2021 | [Plan for live events in Microsoft Teams](/MicrosoftTeams/teams-live-events/plan-for-teams-live-events) | modified |
+| 2/8/2021 | [Manage tags in Microsoft Teams](/MicrosoftTeams/manage-tags) | modified |
 | 2/8/2021 | [Manage Teams templates in the admin center](/MicrosoftTeams/templates-policies) | modified |
+| 2/8/2021 | [Manage user access to Education Insights](/MicrosoftTeams/education-insights-manage-access) | added |
 | 2/8/2021 | [Phone number management for Belgium](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-belgium) | modified |
-| 2/8/2021 | [Release notes](/MicrosoftTeams/rooms/rooms-release-note) | modified |
+| 2/8/2021 | [Plan for live events in Microsoft Teams](/MicrosoftTeams/teams-live-events/plan-for-teams-live-events) | modified |
 | 2/8/2021 | [Plan your upgrade from Skype for Business to Microsoft Teams](/MicrosoftTeams/upgrade-skype-teams) | modified |
+| 2/8/2021 | [Release notes](/MicrosoftTeams/rooms/rooms-release-note) | modified |
+| 2/8/2021 | [Sync Student Information System (SIS) data with Education Insights](/MicrosoftTeams/education-insights-sis-data-sync) | modified |
+| 2/8/2021 | [Use the Teams App Submission API to submit and approve your custom apps](/MicrosoftTeams/submit-approve-custom-apps) | modified |
 | 2/9/2021 | [Create a custom team template in Microsoft Teams](/MicrosoftTeams/create-a-team-template) | modified |
 | 2/9/2021 | [Phones and Devices for Microsoft Teams](/MicrosoftTeams/devices/usb-devices) | modified |
-| 2/10/2021 | [Microsoft Teams auto attendant supported languages](/MicrosoftTeams/create-a-phone-system-auto-attendant-languages) | added |
-| 2/10/2021 | [Microsoft Teams call queue supported languages](/MicrosoftTeams/create-a-phone-system-call-queue-languages) | added |
-| 2/10/2021 | [Set up an auto attendant for Microsoft Teams](/MicrosoftTeams/create-a-phone-system-auto-attendant) | modified |
-| 2/10/2021 | [Create a call queue in Microsoft Teams](/MicrosoftTeams/create-a-phone-system-call-queue) | modified |
-| 2/10/2021 | [Sync Student Information System (SIS) data with Education Insights](/MicrosoftTeams/education-insights-sis-data-sync) | modified |
-| 2/10/2021 | [Information barriers in Microsoft Teams](/MicrosoftTeams/information-barriers-in-teams) | modified |
-| 2/10/2021 | [Deploy Microsoft Teams Rooms with Microsoft 365 or Office 365](/MicrosoftTeams/rooms/with-office-365) | modified |
-| 2/10/2021 | [Microsoft Teams analytics and reporting](/MicrosoftTeams/teams-analytics-and-reports/teams-reporting-reference) | modified |
-| 2/10/2021 | [Microsoft Teams user activity report](/MicrosoftTeams/teams-analytics-and-reports/user-activity-report) | modified |
-| 2/10/2021 | [Teams Contact Center](/MicrosoftTeams/teams-contact-center) | modified |
-| 2/10/2021 | [Introduction to Teams Policy-based Recording for Calling & Meetings](/MicrosoftTeams/teams-recording-policy) | modified |
-| 2/10/2021 | [Use OneDrive for Business and SharePoint for meeting recordings](/MicrosoftTeams/tmr-meeting-recording-change) | modified |
 | 2/10/2021 | [Apps, bots, & connectors in Microsoft Teams](/MicrosoftTeams/deploy-apps-microsoft-teams-landing-page) | modified |
-| 2/10/2021 | [Direct Routing SBA](/MicrosoftTeams/direct-routing-survivable-branch-appliance) | modified |
-| 2/10/2021 | [Purchase third-party apps for Teams](/MicrosoftTeams/purchase-third-party-apps) | modified |
-| 2/10/2021 | [Microsoft Teams Rooms](/MicrosoftTeams/rooms/index) | modified |
 | 2/10/2021 | [Assign Teams add-on licenses to users](/MicrosoftTeams/teams-add-on-licensing/assign-teams-add-on-licenses) | modified |
+| 2/10/2021 | [Create a call queue in Microsoft Teams](/MicrosoftTeams/create-a-phone-system-call-queue) | modified |
+| 2/10/2021 | [Deploy Microsoft Teams Rooms with Microsoft 365 or Office 365](/MicrosoftTeams/rooms/with-office-365) | modified |
+| 2/10/2021 | [Direct Routing SBA](/MicrosoftTeams/direct-routing-survivable-branch-appliance) | modified |
+| 2/10/2021 | [Information barriers in Microsoft Teams](/MicrosoftTeams/information-barriers-in-teams) | modified |
 | 2/10/2021 | [Interoperability between Skype for Business and Microsoft Teams](/MicrosoftTeams/teams-and-skypeforbusiness-coexistence-and-interoperability) | modified |
+| 2/10/2021 | [Introduction to Teams Policy-based Recording for Calling & Meetings](/MicrosoftTeams/teams-recording-policy) | modified |
 | 2/10/2021 | [Manage the Microsoft Teams Exploratory experience](/MicrosoftTeams/teams-exploratory) | modified |
-| 2/11/2021 | [View-only meeting experience](/MicrosoftTeams/view-only-meeting-experience) | added |
-| 2/11/2021 | [Microsoft Teams user activity report](/MicrosoftTeams/teams-analytics-and-reports/user-activity-report) | modified |
+| 2/10/2021 | [Microsoft Teams auto attendant supported languages](/MicrosoftTeams/create-a-phone-system-auto-attendant-languages) | added |
+| 2/10/2021 | [Microsoft Teams analytics and reporting](/MicrosoftTeams/teams-analytics-and-reports/teams-reporting-reference) | modified |
+| 2/10/2021 | [Microsoft Teams call queue supported languages](/MicrosoftTeams/create-a-phone-system-call-queue-languages) | added |
+| 2/10/2021 | [Microsoft Teams Rooms](/MicrosoftTeams/rooms/index) | modified |
+| 2/10/2021 | [Microsoft Teams user activity report](/MicrosoftTeams/teams-analytics-and-reports/user-activity-report) | modified |
+| 2/10/2021 | [Purchase third-party apps for Teams](/MicrosoftTeams/purchase-third-party-apps) | modified |
+| 2/10/2021 | [Set up an auto attendant for Microsoft Teams](/MicrosoftTeams/create-a-phone-system-auto-attendant) | modified |
+| 2/10/2021 | [Sync Student Information System (SIS) data with Education Insights](/MicrosoftTeams/education-insights-sis-data-sync) | modified |
+| 2/10/2021 | [Teams Contact Center](/MicrosoftTeams/teams-contact-center) | modified |
+| 2/10/2021 | [Use OneDrive for Business and SharePoint for meeting recordings](/MicrosoftTeams/tmr-meeting-recording-change) | modified |
 | 2/11/2021 | [Assign policies to your users in Microsoft Teams](/MicrosoftTeams/assign-policies) | modified |
 | 2/11/2021 | [Create a custom team template in Microsoft Teams](/MicrosoftTeams/create-a-team-template) | modified |
 | 2/11/2021 | [Manage phone numbers for your organization](/MicrosoftTeams/manage-phone-numbers-for-your-organization/manage-phone-numbers-for-your-organization) | modified |
+| 2/11/2021 | [Microsoft Teams user activity report](/MicrosoftTeams/teams-analytics-and-reports/user-activity-report) | modified |
 | 2/11/2021 | [Phone number management for Australia](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-australia) | modified |
 | 2/11/2021 | [Phone number management for Austria](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-austria) | modified |
 | 2/11/2021 | [Phone number management for Belgium](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-belgium) | modified |
@@ -88,12 +88,12 @@
 | 2/11/2021 | [Phone number management for the Netherlands](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-the-netherlands) | modified |
 | 2/11/2021 | [Phone number management for the United Kingdom](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-the-u-k) | modified |
 | 2/11/2021 | [Phone number management for the United States](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-the-u-s) | modified |
-| 2/11/2021 | [Public preview in Microsoft Teams](/MicrosoftTeams/public-preview-doc-updates) | modified |
 | 2/11/2021 | [Plan your upgrade from Skype for Business to Microsoft Teams](/MicrosoftTeams/upgrade-skype-teams) | modified |
-| 2/12/2021 | [Teams cloud meeting recording](/MicrosoftTeams/cloud-recording) | modified |
+| 2/11/2021 | [Public preview in Microsoft Teams](/MicrosoftTeams/public-preview-doc-updates) | modified |
+| 2/11/2021 | [View-only meeting experience](/MicrosoftTeams/view-only-meeting-experience) | added |
 | 2/12/2021 | [Add and update reporting labels](/MicrosoftTeams/learn-more-about-site-upload) | modified |
-| 2/12/2021 | [Phone number management for Belgium](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-belgium) | modified |
 | 2/12/2021 | [Reset the Audio Conferencing PIN in Microsoft Teams](/MicrosoftTeams/reset-the-audio-conferencing-pin-in-teams) | modified |
+| 2/12/2021 | [Teams cloud meeting recording](/MicrosoftTeams/cloud-recording) | modified |
 | 2/12/2021 | [View-only meeting experience](/MicrosoftTeams/view-only-meeting-experience) | modified |
 
 
@@ -102,44 +102,44 @@
 
 | Published On |Topic title | Change |
 |------|------------|--------|
-| 2/1/2021 | [Upload tenant and building data in Call Quality Dashboard (CQD)](/MicrosoftTeams/cqd-upload-tenant-building-data) | modified |
-| 2/1/2021 | [IT Admin Guide to Education Insights in Microsoft Teams](/MicrosoftTeams/class-insights) | modified |
-| 2/1/2021 | [Sync Student Information System (SIS) data with Education Insights](/MicrosoftTeams/education-insights-sis-data-sync) | modified |
 | 2/1/2021 | [Information barriers in Microsoft Teams](/MicrosoftTeams/information-barriers-in-teams) | modified |
+| 2/1/2021 | [IT Admin Guide to Education Insights in Microsoft Teams](/MicrosoftTeams/class-insights) | modified |
 | 2/1/2021 | [Manage and monitor Teams](/MicrosoftTeams/manage-teams-overview) | added |
 | 2/1/2021 | [Release notes for Microsoft Teams](/MicrosoftTeams/release-notes/release-notes) | modified |
-| 2/2/2021 | [Use Microsoft 365 and custom connectors](/MicrosoftTeams/office-365-custom-connectors) | modified |
+| 2/1/2021 | [Sync Student Information System (SIS) data with Education Insights](/MicrosoftTeams/education-insights-sis-data-sync) | modified |
+| 2/1/2021 | [Upload tenant and building data in Call Quality Dashboard (CQD)](/MicrosoftTeams/cqd-upload-tenant-building-data) | modified |
 | 2/2/2021 | [Manage policy packages in Microsoft Teams](/MicrosoftTeams/manage-policy-packages) | modified |
 | 2/2/2021 | [Teams Contact Center](/MicrosoftTeams/teams-contact-center) | modified |
-| 2/3/2021 | [Export content with the Microsoft Teams Export APIs](/MicrosoftTeams/export-teams-content) | modified |
-| 2/3/2021 | [Phone number management for Switzerland](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-switzerland) | modified |
+| 2/2/2021 | [Use Microsoft 365 and custom connectors](/MicrosoftTeams/office-365-custom-connectors) | modified |
 | 2/3/2021 | [Connect your Session Border Controller (SBC) to Direct Routing](/MicrosoftTeams/direct-routing-connect-the-sbc) | modified |
-| 2/3/2021 | Microsoft Teams \| Environment Readiness \| Adoption, Discovery | removed |
-| 2/3/2021 | [Teams for Virtual visits](/MicrosoftTeams/expand-teams-across-your-org/healthcare/ehr-admin) | modified |
+| 2/3/2021 | [Export content with the Microsoft Teams Export APIs](/MicrosoftTeams/export-teams-content) | modified |
+| 2/3/2021 | Microsoft Teams \ Environment Readiness \ Adoption, Discovery | removed |
+| 2/3/2021 | [Phone number management for Switzerland](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-switzerland) | modified |
 | 2/3/2021 | [Release notes](/MicrosoftTeams/rooms/rooms-release-note) | modified |
-| 2/4/2021 | [Teams Contact Center](/MicrosoftTeams/teams-contact-center) | modified |
-| 2/4/2021 | [Call Quality Dashboard (CQD) Frequently asked questions (FAQ)](/MicrosoftTeams/cqd-frequently-asked-questions) | modified |
-| 2/4/2021 | [Upgrading from Skype for Business to Teams FAQ](/MicrosoftTeams/faq-journey) | modified |
+| 2/3/2021 | [Teams for Virtual visits](/MicrosoftTeams/expand-teams-across-your-org/healthcare/ehr-admin) | modified |
 | 2/4/2021 | [Audio Conferencing common questions](/MicrosoftTeams/audio-conferencing-common-questions) | modified |
-| 2/4/2021 | [Dimensions and measurements - Call Quality Dashboard (CQD)](/MicrosoftTeams/dimensions-and-measures-available-in-call-quality-dashboard) | modified |
+| 2/4/2021 | [Call Quality Dashboard (CQD) Frequently asked questions (FAQ)](/MicrosoftTeams/cqd-frequently-asked-questions) | modified |
 | 2/4/2021 | [Configure Session Border Controller - Multiple tenants](/MicrosoftTeams/direct-routing-sbc-multiple-tenants) | modified |
-| 2/4/2021 | [Microsoft Teams admin documentation # < 60 chars](/MicrosoftTeams/index) | modified |
-| 2/4/2021 | [Limits and specifications for Microsoft Teams](/MicrosoftTeams/limits-specifications-teams) | modified |
-| 2/4/2021 | [Use the Teams App Submission API to submit and approve your custom apps](/MicrosoftTeams/submit-approve-custom-apps) | modified |
-| 2/4/2021 | [Teams for Virtualized Desktop Infrastructure](/MicrosoftTeams/teams-for-vdi) | modified |
-| 2/4/2021 | [Introduction to Teams Policy-based Recording for Calling & Meetings](/MicrosoftTeams/teams-recording-policy) | modified |
-| 2/4/2021 | [Set up Call Quality Dashboard (CQD)](/MicrosoftTeams/turning-on-and-using-call-quality-dashboard) | modified |
+| 2/4/2021 | [Dimensions and measurements - Call Quality Dashboard (CQD)](/MicrosoftTeams/dimensions-and-measures-available-in-call-quality-dashboard) | modified |
 | 2/4/2021 | [Get started upgrading Skype for Business to Teams](/MicrosoftTeams/upgrade-start-here) | modified |
-| 2/5/2021 | [Overview of security and compliance](/MicrosoftTeams/security-compliance-overview) | modified |
-| 2/5/2021 | [Microsoft Teams usage report](/MicrosoftTeams/teams-analytics-and-reports/teams-usage-report) | modified |
-| 2/5/2021 | [Teams experience in a Microsoft 365 Multi-Geo-enabled environment](/MicrosoftTeams/teams-experience-o365odb-spo-multi-geo) | modified |
-| 2/5/2021 | [Manage Teams templates in the admin center](/MicrosoftTeams/templates-policies) | added |
+| 2/4/2021 | [Introduction to Teams Policy-based Recording for Calling & Meetings](/MicrosoftTeams/teams-recording-policy) | modified |
+| 2/4/2021 | [Limits and specifications for Microsoft Teams](/MicrosoftTeams/limits-specifications-teams) | modified |
+| 2/4/2021 | [Microsoft Teams admin documentation # < 60 chars](/MicrosoftTeams/index) | modified |
+| 2/4/2021 | [Set up Call Quality Dashboard (CQD)](/MicrosoftTeams/turning-on-and-using-call-quality-dashboard) | modified |
+| 2/4/2021 | [Teams Contact Center](/MicrosoftTeams/teams-contact-center) | modified |
+| 2/4/2021 | [Teams for Virtualized Desktop Infrastructure](/MicrosoftTeams/teams-for-vdi) | modified |
+| 2/4/2021 | [Upgrading from Skype for Business to Teams FAQ](/MicrosoftTeams/faq-journey) | modified |
+| 2/4/2021 | [Use the Teams App Submission API to submit and approve your custom apps](/MicrosoftTeams/submit-approve-custom-apps) | modified |
 | 2/5/2021 | [Create a call queue in Microsoft Teams](/MicrosoftTeams/create-a-phone-system-call-queue) | modified |
-| 2/5/2021 | [Teams for Virtual visits](/MicrosoftTeams/expand-teams-across-your-org/healthcare/ehr-admin) | modified |
 | 2/5/2021 | [Get started with Teams for healthcare organizations](/MicrosoftTeams/expand-teams-across-your-org/healthcare/teams-in-hc) | modified |
+| 2/5/2021 | [Install Teams using Microsoft Endpoint Configuration Manager](/MicrosoftTeams/msi-deployment) | modified |
 | 2/5/2021 | [Limits and specifications for Microsoft Teams](/MicrosoftTeams/limits-specifications-teams) | modified |
 | 2/5/2021 | [Manage meeting policies](/MicrosoftTeams/meeting-policies-in-teams) | modified |
-| 2/5/2021 | [Install Teams using Microsoft Endpoint Configuration Manager](/MicrosoftTeams/msi-deployment) | modified |
+| 2/5/2021 | [Manage Teams templates in the admin center](/MicrosoftTeams/templates-policies) | added |
+| 2/5/2021 | [Microsoft Teams usage report](/MicrosoftTeams/teams-analytics-and-reports/teams-usage-report) | modified |
+| 2/5/2021 | [Teams experience in a Microsoft 365 Multi-Geo-enabled environment](/MicrosoftTeams/teams-experience-o365odb-spo-multi-geo) | modified |
+| 2/5/2021 | [Teams for Virtual visits](/MicrosoftTeams/expand-teams-across-your-org/healthcare/ehr-admin) | modified |
+| 2/5/2021 | [Overview of security and compliance](/MicrosoftTeams/security-compliance-overview) | modified |
 | 2/5/2021 | [Plan for Teams auto attendants and call queues](/MicrosoftTeams/plan-auto-attendant-call-queue) | modified |
 
 
@@ -148,36 +148,36 @@
 
 | Published On |Topic title | Change |
 |------|------------|--------|
+| 1/25/2021 | [Conduct an eDiscovery investigation of content](/MicrosoftTeams/ediscovery-investigation) | modified |
 | 1/25/2021 | [Create an org-wide team in Microsoft Teams](/MicrosoftTeams/create-an-org-wide-team) | modified |
 | 1/25/2021 | [Limits and specifications for Microsoft Teams](/MicrosoftTeams/limits-specifications-teams) | modified |
 | 1/25/2021 | [Manage emergency calling policies in Microsoft Teams](/MicrosoftTeams/manage-emergency-calling-policies) | modified |
 | 1/25/2021 | [Overview of security and compliance](/MicrosoftTeams/security-compliance-overview) | modified |
-| 1/25/2021 | [Teams upgrade planning workshops](/MicrosoftTeams/upgrade-workshops-landing-page) | modified |
-| 1/25/2021 | [Use OneDrive for Business and SharePoint for meeting recordings](/MicrosoftTeams/tmr-meeting-recording-change) | modified |
-| 1/25/2021 | [Use Content Search in Microsoft Teams](/MicrosoftTeams/content-search) | modified |
-| 1/25/2021 | [Conduct an eDiscovery investigation of content](/MicrosoftTeams/ediscovery-investigation) | modified |
 | 1/25/2021 | [Place a Microsoft Teams user or team on legal hold](/MicrosoftTeams/legal-hold) | modified |
-| 1/26/2021 | [Sync Student Information System (SIS) data with Education Insights](/MicrosoftTeams/education-insights-sis-data-sync) | added |
-| 1/26/2021 | [Microsoft Teams Rooms requirements](/MicrosoftTeams/rooms/requirements) | modified |
+| 1/25/2021 | [Teams upgrade planning workshops](/MicrosoftTeams/upgrade-workshops-landing-page) | modified |
+| 1/25/2021 | [Use Content Search in Microsoft Teams](/MicrosoftTeams/content-search) | modified |
+| 1/25/2021 | [Use OneDrive for Business and SharePoint for meeting recordings](/MicrosoftTeams/tmr-meeting-recording-change) | modified |
 | 1/26/2021 | [Dimensions and measurements - Call Quality Dashboard (CQD)](/MicrosoftTeams/dimensions-and-measures-available-in-call-quality-dashboard) | modified |
+| 1/26/2021 | [Microsoft Teams Rooms requirements](/MicrosoftTeams/rooms/requirements) | modified |
 | 1/26/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
+| 1/26/2021 | [Sync Student Information System (SIS) data with Education Insights](/MicrosoftTeams/education-insights-sis-data-sync) | added |
 | 1/27/2021 | [Advanced Communications add-on for Microsoft Teams](/MicrosoftTeams/teams-add-on-licensing/advanced-communications) | modified |
-| 1/27/2021 | [Microsoft Teams add-on licenses](/MicrosoftTeams/teams-add-on-licensing/microsoft-teams-add-on-licensing) | modified |
 | 1/27/2021 | [Dimensions and measurements - Call Quality Dashboard (CQD)](/MicrosoftTeams/dimensions-and-measures-available-in-call-quality-dashboard) | modified |
-| 1/27/2021 | [Plan for Microsoft 365 Groups when creating teams](/MicrosoftTeams/plan-office-365-groups) | modified |
+| 1/27/2021 | [Microsoft Teams add-on licenses](/MicrosoftTeams/teams-add-on-licensing/microsoft-teams-add-on-licensing) | modified |
 | 1/27/2021 | [Phones and Devices for Microsoft Teams](/MicrosoftTeams/devices/usb-devices) | modified |
-| 1/28/2021 | [Use the Microsoft Teams Meeting add-in in Outlook](/MicrosoftTeams/teams-add-in-for-outlook) | modified |
+| 1/27/2021 | [Plan for Microsoft 365 Groups when creating teams](/MicrosoftTeams/plan-office-365-groups) | modified |
 | 1/28/2021 | [Manage the Praise app in the Teams admin center](/MicrosoftTeams/manage-praise-app) | modified |
-| 1/28/2021 | [Public preview in Microsoft Teams](/MicrosoftTeams/public-preview-doc-updates) | modified |
 | 1/28/2021 | [Microsoft Teams Rooms managed service](/MicrosoftTeams/rooms/microsoft-teams-rooms-premium) | modified |
+| 1/28/2021 | [Public preview in Microsoft Teams](/MicrosoftTeams/public-preview-doc-updates) | modified |
+| 1/28/2021 | [Use the Microsoft Teams Meeting add-in in Outlook](/MicrosoftTeams/teams-add-in-for-outlook) | modified |
 | 1/28/2021 | [Use the Teams App Submission API to submit and approve your custom apps](/MicrosoftTeams/submit-approve-custom-apps) | modified |
-| 1/29/2021 | [Teams cloud meeting recording](/MicrosoftTeams/cloud-recording) | modified |
-| 1/29/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
-| 1/29/2021 | [Teams for Virtual visits](/MicrosoftTeams/expand-teams-across-your-org/healthcare/ehr-admin) | modified |
+| 1/29/2021 | [Known issues](/MicrosoftTeams/rooms/known-issues) | modified |
 | 1/29/2021 | [Manage external access (federation)](/MicrosoftTeams/manage-external-access) | modified |
 | 1/29/2021 | [Native chat experience for external (federated) users in Microsoft Teams](/MicrosoftTeams/native-chat-for-external-users) | modified |
-| 1/29/2021 | [Known issues](/MicrosoftTeams/rooms/known-issues) | modified |
+| 1/29/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
 | 1/29/2021 | [Teams and Skype interoperability](/MicrosoftTeams/teams-skype-interop) | modified |
+| 1/29/2021 | [Teams cloud meeting recording](/MicrosoftTeams/cloud-recording) | modified |
+| 1/29/2021 | [Teams for Virtual visits](/MicrosoftTeams/expand-teams-across-your-org/healthcare/ehr-admin) | modified |
 
 
 ## Week of January 18, 2021
@@ -185,64 +185,64 @@
 
 | Published On |Topic title | Change |
 |------|------------|--------|
-| 1/21/2021 | [Plan Direct Routing](/MicrosoftTeams/direct-routing-plan) | modified |
-| 1/21/2021 | [Configure Session Border Controller - Multiple tenants](/MicrosoftTeams/direct-routing-sbc-multiple-tenants) | modified |
-| 1/21/2021 | [Phone number management for France](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-france) | modified |
-| 1/21/2021 | [Install, manage, and assign permissions for the Teams Learning app (private preview)](/MicrosoftTeams/teams-learning-app-overview) | modified |
-| 1/21/2021 | [Create a Teams 'Intranet Portal app' from a SharePoint Online site or page](/MicrosoftTeams/teams-standalone-static-tabs-using-spo-sites) | modified |
-| 1/19/2021 | [Manage meeting settings](/MicrosoftTeams/meeting-settings-in-teams) | modified |
-| 1/19/2021 | [Use OneDrive for Business and SharePoint for meeting recordings](/MicrosoftTeams/tmr-meeting-recording-change) | modified |
-| 1/21/2021 | [Audio Conferencing Dial-Out/Call Me At minutes](/MicrosoftTeams/audio-conferencing-subscription-dial-out) | modified |
-| 1/21/2021 | Set up additional call attendants and call trees | removed |
-| 1/21/2021 | Set up call queues | removed |
-| 1/21/2021 | [Change phone numbers on Audio Conferencing bridge](/MicrosoftTeams/change-the-phone-numbers-on-your-audio-conferencing-bridge) | modified |
-| 1/21/2021 | [Change the settings for an Audio Conferencing bridge](/MicrosoftTeams/change-the-settings-for-an-audio-conferencing-bridge) | modified |
-| 1/21/2021 | [Teams cloud meeting recording](/MicrosoftTeams/cloud-recording) | modified |
-| 1/21/2021 | [Complimentary dial-out period](/MicrosoftTeams/complimentary-dial-out-period) | modified |
-| 1/21/2021 | [Troubleshoot connectivity issues with Teams client](/MicrosoftTeams/connectivity-issues) | modified |
-| 1/21/2021 | [Set up an auto attendant for Microsoft Teams](/MicrosoftTeams/create-a-phone-system-auto-attendant) | modified |
-| 1/21/2021 | [Meetings and conferencing in Microsoft Teams](/MicrosoftTeams/deploy-meetings-microsoft-teams-landing-page) | modified |
-| 1/21/2021 | [Auto attendant and call queue dialing and voice recognition reference](/MicrosoftTeams/dial-voice-reference) | modified |
-| 1/21/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
-| 1/21/2021 | [Add and update reporting labels](/MicrosoftTeams/learn-more-about-site-upload) | modified |
-| 1/21/2021 | [Manage meeting policies](/MicrosoftTeams/meeting-policies-in-teams) | modified |
-| 1/21/2021 | [Plan for Teams auto attendants and call queues](/MicrosoftTeams/plan-auto-attendant-call-queue) | modified |
-| 1/21/2021 | [Reset the Audio Conferencing PIN in Microsoft Teams](/MicrosoftTeams/reset-the-audio-conferencing-pin-in-teams) | modified |
-| 1/21/2021 | [Microsoft Teams Rooms requirements](/MicrosoftTeams/rooms/requirements) | modified |
-| 1/21/2021 | [See a list of phone numbers in your organization](/MicrosoftTeams/see-a-list-of-phone-numbers-in-your-organization) | modified |
-| 1/21/2021 | [Use activity reports for Microsoft Teams](/MicrosoftTeams/teams-activity-reports) | modified |
-| 1/21/2021 | [What are Microsoft Teams live events?](/MicrosoftTeams/teams-live-events/what-are-teams-live-events) | modified |
-| 1/21/2021 | Small business example — Set up an Auto Attendant | removed |
-| 1/21/2021 | [Teams voice Contoso case study](/MicrosoftTeams/voice-case-study-call-queues) | modified |
-| 1/21/2021 | [What are Cloud auto attendants?](/MicrosoftTeams/what-are-phone-system-auto-attendants) | modified |
-| 1/19/2021 | [Set up an auto attendant for Microsoft Teams - small business tutorial](/MicrosoftTeams/business-voice/create-a-phone-system-auto-attendant-smb) | added |
-| 1/19/2021 | [Create a call queue in Microsoft Teams - small business tutorial](/MicrosoftTeams/business-voice/create-a-phone-system-call-queue-smb) | added |
-| 1/19/2021 | [Approvals application availability in Teams](/MicrosoftTeams/approval-admin) | modified |
-| 1/19/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
-| 1/19/2021 | [Get started with Teams for healthcare organizations](/MicrosoftTeams/expand-teams-across-your-org/healthcare/teams-in-hc) | modified |
-| 1/19/2021 | [Shifts for Teams](/MicrosoftTeams/expand-teams-across-your-org/shifts-for-teams-landing-page) | modified |
-| 1/19/2021 | [Manage shift-based access for Frontline Workers in Teams](/MicrosoftTeams/expand-teams-across-your-org/shifts/manage-shift-based-access-flw) | modified |
-| 1/19/2021 | [Manage the Shifts app for your organization](/MicrosoftTeams/expand-teams-across-your-org/shifts/manage-the-shifts-app-for-your-organization-in-teams) | modified |
-| 1/19/2021 | [Microsoft StaffHub has been retired](/MicrosoftTeams/expand-teams-across-your-org/shifts/microsoft-staffhub-to-be-retired) | modified |
-| 1/19/2021 | [ITAdmin information for Microsoft Teams for RealWear client (Preview)](/MicrosoftTeams/flw-realwear) | modified |
-| 1/19/2021 | [Provisioning Microsoft Teams at scale for Frontline Workers](/MicrosoftTeams/flw-scripted-deployment) | modified |
-| 1/19/2021 | [Guest access in Microsoft Teams](/MicrosoftTeams/guest-access) | modified |
-| 1/19/2021 | [Teams sessions at Ignite 2020](/MicrosoftTeams/ignite-2020-landing-page) | modified |
-| 1/19/2021 | [Manage the Praise app in the Teams admin center](/MicrosoftTeams/manage-praise-app) | modified |
-| 1/19/2021 | [Manage the Tasks app for your organization in Microsoft Teams](/MicrosoftTeams/manage-tasks-app) | modified |
-| 1/19/2021 | [Office 365 Government - DoD deployments](/MicrosoftTeams/plan-for-government-dod) | modified |
-| 1/19/2021 | [Microsoft 365 Government - GCC High deployments](/MicrosoftTeams/plan-for-government-gcc-high) | modified |
-| 1/19/2021 | [Required mobile diagnostic data for Microsoft Teams](/MicrosoftTeams/policy-control-diagnostic-data-mobile) | modified |
-| 1/19/2021 | [Teams policy packages for government](/MicrosoftTeams/policy-packages-gov) | modified |
-| 1/19/2021 | [Release notes for Microsoft Teams](/MicrosoftTeams/release-notes/release-notes) | modified |
-| 1/19/2021 | [Sign in to Microsoft Teams](/MicrosoftTeams/sign-in-teams) | modified |
-| 1/19/2021 | [Stream classification in Call Quality Dashboard (CQD)](/MicrosoftTeams/stream-classification-in-call-quality-dashboard) | modified |
-| 1/19/2021 | [Manage app setup policies in Microsoft Teams](/MicrosoftTeams/teams-app-setup-policies) | modified |
-| 1/19/2021 | [Teams Contact Center](/MicrosoftTeams/teams-contact-center) | modified |
-| 1/19/2021 | [Roll out Microsoft Teams First](/MicrosoftTeams/teams-first-overview) | modified |
-| 1/19/2021 | [Assess organizational change readiness for your Skype for Business to Teams upgrade](/MicrosoftTeams/upgrade-org-change-readiness) | modified |
-| 1/19/2021 | [What are Cloud auto attendants?](/MicrosoftTeams/what-are-phone-system-auto-attendants) | modified |
-| 1/22/2021 | [Overview of security and compliance](/MicrosoftTeams/security-compliance-overview) | modified |
-| 1/22/2021 | [Sensitivity labels for Microsoft Teams](/MicrosoftTeams/sensitivity-labels) | modified |
 | 1/22/2021 | [Advanced Communications add-on for Microsoft Teams](/MicrosoftTeams/teams-add-on-licensing/advanced-communications) | modified |
 | 1/22/2021 | [Create a Teams 'Intranet Portal app' from a SharePoint Online site or page](/MicrosoftTeams/teams-standalone-static-tabs-using-spo-sites) | modified |
+| 1/22/2021 | [Overview of security and compliance](/MicrosoftTeams/security-compliance-overview) | modified |
+| 1/22/2021 | [Sensitivity labels for Microsoft Teams](/MicrosoftTeams/sensitivity-labels) | modified |
+| 1/21/2021 | [Add and update reporting labels](/MicrosoftTeams/learn-more-about-site-upload) | modified |
+| 1/21/2021 | [Audio Conferencing Dial-Out/Call Me At minutes](/MicrosoftTeams/audio-conferencing-subscription-dial-out) | modified |
+| 1/21/2021 | [Auto attendant and call queue dialing and voice recognition reference](/MicrosoftTeams/dial-voice-reference) | modified |
+| 1/21/2021 | [Change phone numbers on Audio Conferencing bridge](/MicrosoftTeams/change-the-phone-numbers-on-your-audio-conferencing-bridge) | modified |
+| 1/21/2021 | [Change the settings for an Audio Conferencing bridge](/MicrosoftTeams/change-the-settings-for-an-audio-conferencing-bridge) | modified |
+| 1/21/2021 | [Create a Teams 'Intranet Portal app' from a SharePoint Online site or page](/MicrosoftTeams/teams-standalone-static-tabs-using-spo-sites) | modified |
+| 1/21/2021 | [Complimentary dial-out period](/MicrosoftTeams/complimentary-dial-out-period) | modified |
+| 1/21/2021 | [Configure Session Border Controller - Multiple tenants](/MicrosoftTeams/direct-routing-sbc-multiple-tenants) | modified |
+| 1/21/2021 | [Install, manage, and assign permissions for the Teams Learning app (private preview)](/MicrosoftTeams/teams-learning-app-overview) | modified |
+| 1/21/2021 | [Manage meeting policies](/MicrosoftTeams/meeting-policies-in-teams) | modified |
+| 1/21/2021 | [Meetings and conferencing in Microsoft Teams](/MicrosoftTeams/deploy-meetings-microsoft-teams-landing-page) | modified |
+| 1/21/2021 | [Microsoft Teams Rooms requirements](/MicrosoftTeams/rooms/requirements) | modified |
+| 1/21/2021 | [Phone number management for France](/MicrosoftTeams/manage-phone-numbers-for-your-organization/phone-number-management-for-france) | modified |
+| 1/21/2021 | [Plan Direct Routing](/MicrosoftTeams/direct-routing-plan) | modified |
+| 1/21/2021 | [Plan for Teams auto attendants and call queues](/MicrosoftTeams/plan-auto-attendant-call-queue) | modified |
+| 1/21/2021 | [Reset the Audio Conferencing PIN in Microsoft Teams](/MicrosoftTeams/reset-the-audio-conferencing-pin-in-teams) | modified |
+| 1/21/2021 | [See a list of phone numbers in your organization](/MicrosoftTeams/see-a-list-of-phone-numbers-in-your-organization) | modified |
+| 1/21/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
+| 1/21/2021 | [Set up an auto attendant for Microsoft Teams](/MicrosoftTeams/create-a-phone-system-auto-attendant) | modified |
+| 1/21/2021 | Set up additional call attendants and call trees | removed |
+| 1/21/2021 | Set up call queues | removed |
+| 1/21/2021 | Small business example — Set up an Auto Attendant | removed |
+| 1/21/2021 | [Teams cloud meeting recording](/MicrosoftTeams/cloud-recording) | modified |
+| 1/21/2021 | [Teams voice Contoso case study](/MicrosoftTeams/voice-case-study-call-queues) | modified |
+| 1/21/2021 | [Troubleshoot connectivity issues with Teams client](/MicrosoftTeams/connectivity-issues) | modified |
+| 1/21/2021 | [Use activity reports for Microsoft Teams](/MicrosoftTeams/teams-activity-reports) | modified |
+| 1/21/2021 | [What are Cloud auto attendants?](/MicrosoftTeams/what-are-phone-system-auto-attendants) | modified |
+| 1/21/2021 | [What are Microsoft Teams live events?](/MicrosoftTeams/teams-live-events/what-are-teams-live-events) | modified |
+| 1/19/2021 | [Create a call queue in Microsoft Teams - small business tutorial](/MicrosoftTeams/business-voice/create-a-phone-system-call-queue-smb) | added |
+| 1/19/2021 | [Approvals application availability in Teams](/MicrosoftTeams/approval-admin) | modified |
+| 1/19/2021 | [Assess organizational change readiness for your Skype for Business to Teams upgrade](/MicrosoftTeams/upgrade-org-change-readiness) | modified |
+| 1/19/2021 | [Get started with Teams for healthcare organizations](/MicrosoftTeams/expand-teams-across-your-org/healthcare/teams-in-hc) | modified |
+| 1/19/2021 | [Guest access in Microsoft Teams](/MicrosoftTeams/guest-access) | modified |
+| 1/19/2021 | [ITAdmin information for Microsoft Teams for RealWear client (Preview)](/MicrosoftTeams/flw-realwear) | modified |
+| 1/19/2021 | [Manage app setup policies in Microsoft Teams](/MicrosoftTeams/teams-app-setup-policies) | modified |
+| 1/19/2021 | [Manage meeting settings](/MicrosoftTeams/meeting-settings-in-teams) | modified |
+| 1/19/2021 | [Manage shift-based access for Frontline Workers in Teams](/MicrosoftTeams/expand-teams-across-your-org/shifts/manage-shift-based-access-flw) | modified |
+| 1/19/2021 | [Manage the praise app in the Teams admin center](/MicrosoftTeams/manage-praise-app) | modified |
+| 1/19/2021 | [Manage the shifts app for your organization](/MicrosoftTeams/expand-teams-across-your-org/shifts/manage-the-shifts-app-for-your-organization-in-teams) | modified |
+| 1/19/2021 | [Manage the tasks app for your organization in Microsoft Teams](/MicrosoftTeams/manage-tasks-app) | modified |
+| 1/19/2021 | [Microsoft StaffHub has been retired](/MicrosoftTeams/expand-teams-across-your-org/shifts/microsoft-staffhub-to-be-retired) | modified |
+| 1/19/2021 | [Microsoft 365 Government - GCC High deployments](/MicrosoftTeams/plan-for-government-gcc-high) | modified |
+| 1/19/2021 | [Office 365 Government - DoD deployments](/MicrosoftTeams/plan-for-government-dod) | modified |
+| 1/19/2021 | [Provisioning Microsoft Teams at scale for Frontline Workers](/MicrosoftTeams/flw-scripted-deployment) | modified |
+| 1/19/2021 | [Release notes for Microsoft Teams](/MicrosoftTeams/release-notes/release-notes) | modified |
+| 1/19/2021 | [Required mobile diagnostic data for Microsoft Teams](/MicrosoftTeams/policy-control-diagnostic-data-mobile) | modified |
+| 1/19/2021 | [Roll out Microsoft Teams First](/MicrosoftTeams/teams-first-overview) | modified |
+| 1/19/2021 | [Session Border Controllers certified for Direct Routing](/MicrosoftTeams/direct-routing-border-controllers) | modified |
+| 1/19/2021 | [Set up an auto attendant for Microsoft Teams - small business tutorial](/MicrosoftTeams/business-voice/create-a-phone-system-auto-attendant-smb) | added |
+| 1/19/2021 | [Shifts for Teams](/MicrosoftTeams/expand-teams-across-your-org/shifts-for-teams-landing-page) | modified |
+| 1/19/2021 | [Sign in to Microsoft Teams](/MicrosoftTeams/sign-in-teams) | modified |
+| 1/19/2021 | [Stream classification in Call Quality Dashboard (CQD)](/MicrosoftTeams/stream-classification-in-call-quality-dashboard) | modified |
+| 1/19/2021 | [Teams Contact Center](/MicrosoftTeams/teams-contact-center) | modified |
+| 1/19/2021 | [Teams policy packages for government](/MicrosoftTeams/policy-packages-gov) | modified |
+| 1/19/2021 | [Teams sessions at Ignite 2020](/MicrosoftTeams/ignite-2020-landing-page) | modified |
+| 1/19/2021 | [Use OneDrive for Business and SharePoint for meeting recordings](/MicrosoftTeams/tmr-meeting-recording-change) | modified |
+| 1/19/2021 | [What are Cloud auto attendants?](/MicrosoftTeams/what-are-phone-system-auto-attendants) | modified |


### PR DESCRIPTION
as per user report issue #6859, so i have  arranged all the  notes  in English alphabetical order with date wise   in ascending order, 
i found  in 2/17/2021 there are  two same names  **Teams for Remote Desktop** one is  removed  and the other is  added,
i kept both while editing, the author of the article should decide whether to keep or remove it.

I took care while adjusting and arranging in order.