### PR TITLE
Update configure-dynamic-emergency-calling.md

### DIFF
--- a/Teams/configure-dynamic-emergency-calling.md
+++ b/Teams/configure-dynamic-emergency-calling.md
@@ -84,7 +84,7 @@ The following clients are currently supported.  Check back often to see updates 
 > 
 
 > [!NOTE]
-> Dynamic emergency calling on Teams phones will not suport WAP for LIS matching.
+> Dynamic emergency calling on Teams phones does not support WAP for LIS matching.
 
 ## Assign emergency addresses
 

--- a/Teams/configure-dynamic-emergency-calling.md
+++ b/Teams/configure-dynamic-emergency-calling.md
@@ -81,6 +81,10 @@ The following clients are currently supported.  Check back often to see updates 
 
 > [!NOTE]
 > Dynamic emergency calling including security desk notification isn't supported on the Teams web client. To prevent users from using the Teams web client to call PSTN numbers, you can set a Teams calling policy and turn off the **Allow web PSTN calling** setting. To learn more, see [Calling policies in Teams](teams-calling-policy.md) and [Set-CsTeamsCallingPolicy](https://docs.microsoft.com/powershell/module/skype/set-csteamscallingpolicy?view=skype-ps).
+> 
+
+> [!NOTE]
+> Dynamic emergency calling on Teams phones will not suport WAP for LIS matching.
 
 ## Assign emergency addresses
 


### PR DESCRIPTION
Working with customer and engineering confirmed that Teams phones will not support WAP - https://portal.microsofticm.com/imp/v3/incidents/details/231579196/home.