### PR TITLE
Added notes on how sharing works

### DIFF
--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -154,7 +154,7 @@ Closed captions are supported for Teams meeting recordings for 60 days from when
 Closed captions aren't fully supported if the Teams Meeting Recording is moved or copied from its original location on OneDrive for Business or SharePoint.
 
 > [!NOTE]
->There will be English-only closed captions (meeting transcription is not yet available in GCC) 
+> There will be English-only closed captions (meeting transcription is not yet available in GCC).
 
 **How will my storage quota be impacted?**
 

--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -139,7 +139,7 @@ Since videos are just like any other file in OneDrive for Business and SharePoin
 
 - For Channel meetings, permissions are inherited from the owners and members list in the channel.
 
->[!NOTE]
+> [!NOTE]
 >You'll not get an email when the recording finishes saving, but the recording will appear in the meeting chat once it’s finished. This will happen much quicker than it did in Stream previously
 >You can control with whom you share the recording, but you won't be able to block people with shared access from downloading the recording.  
 

--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -139,6 +139,10 @@ Since videos are just like any other file in OneDrive for Business and SharePoin
 
 - For Channel meetings, permissions are inherited from the owners and members list in the channel.
 
+>[!NOTE]
+>You'll not get an email when the recording finishes saving, but the recording will appear in the meeting chat once it’s finished. This will happen much quicker than it did in Stream previously
+>You can control with whom you share the recording, but you won't be able to block people with shared access from downloading the recording.  
+
 **How can I manage captions?**
 
 Closed captions for Teams meeting recordings will be available during playback only if the user had transcription turned on at the time of recording. Admins must [turn on recording transcription via policy]( https://docs.microsoft.com/microsoftteams/cloud-recording#turn-on-or-turn-off-recording-transcription) to ensure their users have the option to record meetings with transcription.
@@ -148,6 +152,9 @@ Captions help create inclusive content for viewers of all abilities. As an owner
 Closed captions are supported for Teams meeting recordings for 60 days from when the meeting is recorded.
 
 Closed captions aren't fully supported if the Teams Meeting Recording is moved or copied from its original location on OneDrive for Business or SharePoint.
+
+>[!NOTE]
+>There will be English-only closed captions (meeting transcription is not yet available in GCC) 
 
 **How will my storage quota be impacted?**
 

--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -140,7 +140,7 @@ Since videos are just like any other file in OneDrive for Business and SharePoin
 - For Channel meetings, permissions are inherited from the owners and members list in the channel.
 
 > [!NOTE]
->You'll not get an email when the recording finishes saving, but the recording will appear in the meeting chat once it’s finished. This will happen much quicker than it did in Stream previously
+> You'll not get an email when the recording finishes saving, but the recording will appear in the meeting chat once it’s finished. This will happen much quicker than it did in Stream previously.
 > You can control with whom you share the recording, but you won't be able to block people with shared access from downloading the recording.  
 
 **How can I manage captions?**

--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -141,7 +141,7 @@ Since videos are just like any other file in OneDrive for Business and SharePoin
 
 > [!NOTE]
 >You'll not get an email when the recording finishes saving, but the recording will appear in the meeting chat once it’s finished. This will happen much quicker than it did in Stream previously
->You can control with whom you share the recording, but you won't be able to block people with shared access from downloading the recording.  
+> You can control with whom you share the recording, but you won't be able to block people with shared access from downloading the recording.  
 
 **How can I manage captions?**
 

--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -153,7 +153,7 @@ Closed captions are supported for Teams meeting recordings for 60 days from when
 
 Closed captions aren't fully supported if the Teams Meeting Recording is moved or copied from its original location on OneDrive for Business or SharePoint.
 
->[!NOTE]
+> [!NOTE]
 >There will be English-only closed captions (meeting transcription is not yet available in GCC) 
 
 **How will my storage quota be impacted?**


### PR DESCRIPTION
Added notes on how sharing works as per the article:
https://techcommunity.microsoft.com/t5/public-sector-blog/microsoft-teams-recorded-meeting-storage-in-onedrive-for/ba-p/2030120