### PR TITLE
Updating Legacy CQD.Lync.com retirement

### DIFF
--- a/Teams/CQD-what-is-call-quality-dashboard.md
+++ b/Teams/CQD-what-is-call-quality-dashboard.md
@@ -46,12 +46,12 @@ In CQD, we encourage you to upload building and endpoint information, which lets
 
 Don't miss our [Manage call and meeting quality](quality-of-experience-review-guide.md) article, which offers in-depth guidance for the Teams admin or support engineer responsible for managing service quality in Teams.
 
-## Older version of CQD (CQD.lync.com)
+## Legacy version of CQD (CQD.lync.com)
 
-The current version of CQD (https://CQD.Teams.microsoft.com) is replacing the older version of CQD (https://CQD.lync.com). You can still use CQD.lync.com (available from the Skype for Business admin center), but as of July 1, 2020, it's using the data from CQD.Teams.microsoft.com. We'll turn off access to CQD.lync.com soon, so you should move to CQD.Teams.microsoft.com if you haven't already done so.
+The current version of CQD (https://CQD.Teams.microsoft.com) has replaced the legacy version of CQD (https://CQD.lync.com). You can still use CQD.lync.com (available from the Skype for Business admin center), but as of July 1, 2020, it's using the data from CQD.Teams.microsoft.com and you can no longer view or modify your building or query data from the old CQD (CQD.lync.com). If you haven't already migrated this data from CQD.lync.com and still need it, log a support ticket.
 
 > [!IMPORTANT]
-> As of July 1, 2020, you can no longer view or modify your building or query data from the old CQD (CQD.lync.com). If you haven't already migrated this data from CQD.lync.com and still need it, log a support ticket.
+> As of July 31, 2021, we are retiring the legacy version of CQD (CQD.lync.com). After that date, you will be automatically redirected to CQD.Teams.microsoft.com when attempting to access CQD.lync.com, and any unmigrated building or query data will be lost.
 
 ## Use Power BI to analyze CQD data
 


### PR DESCRIPTION
CQD.Lync.com is being discontinued July 31, 2021 to align with the shut down for SfBO (announced on 3/30/2021 in MC247823).