### PR TITLE
Activity feed notification update for legal hold and IB

### DIFF
--- a/Teams/information-barriers-in-teams.md
+++ b/Teams/information-barriers-in-teams.md
@@ -24,7 +24,7 @@ Information barriers (IBs) are policies that an admin can configure to prevent i
 
 >[!NOTE]
 >- Information barrier (IB) groups cannot be created across tenants.
->- Using bots, Azure Active Directory (Azure AD) apps, API to send activity feed notification and some APIs to add users is not supported in version 1.
+>- Using bots, Azure Active Directory (Azure AD) apps, APIs to send activity feed notifications, and some APIs to add users is not supported in version 1.
 >- Private channels are compliant to IB policies that you configure.
 >- New: For information about support for barriers for SharePoint sites that are connected to Teams, see [Segments associated with Microsoft Teams sites](/sharepoint/information-barriers#segments-associated-with-microsoft-teams-sites).
 

--- a/Teams/information-barriers-in-teams.md
+++ b/Teams/information-barriers-in-teams.md
@@ -24,7 +24,7 @@ Information barriers (IBs) are policies that an admin can configure to prevent i
 
 >[!NOTE]
 >- Information barrier (IB) groups cannot be created across tenants.
->- Using bots, Azure Active Directory (Azure AD) apps, and some APIs to add users is not supported in version 1.
+>- Using bots, Azure Active Directory (Azure AD) apps, API to send activity feed notification and some APIs to add users is not supported in version 1.
 >- Private channels are compliant to IB policies that you configure.
 >- New: For information about support for barriers for SharePoint sites that are connected to Teams, see [Segments associated with Microsoft Teams sites](/sharepoint/information-barriers#segments-associated-with-microsoft-teams-sites).
 

--- a/Teams/legal-hold.md
+++ b/Teams/legal-hold.md
@@ -29,6 +29,7 @@ Within Microsoft Teams, an entire team or select users can be put on hold or leg
 
 > [!NOTE]
 > Placing a user on hold does not automatically place a group on hold or vice-versa.
+> Notifications sent in activity feed cannot be put under legal hold.
 
 To put a user or a team on legal hold:
 


### PR DESCRIPTION
updated the document to reflect how legal hold and information barrier policies will work on notifications sent in teams' activity feed using Graph API - https://docs.microsoft.com/en-us/graph/teams-send-activityfeednotifications