### PR TITLE
Clearer PowerShell usage guidance for view-only experience

### DIFF
--- a/Teams/view-only-meeting-experience.md
+++ b/Teams/view-only-meeting-experience.md
@@ -39,7 +39,16 @@ Attendees will be able to join the view-only experience through desktop, web, an
 
 ## Teams view-only experience controls
 
-You enable the view-only experience using PowerShell.
+You enable the view-only experience using the [`Set-CsTeamsMeetingPolicy`](https://docs.microsoft.com/en-us/powershell/module/skype/set-csteamsmeetingpolicy?view=skype-ps) cmdlet from the [SkypeForBusiness PowerShell module](https://docs.microsoft.com/en-us/powershell/module/skype/?view=skype-ps) or at least version 2.0.0 of the [MicrosoftTeams module](https://www.powershellgallery.com/packages/MicrosoftTeams).
+
+To use the recommended `MicrosoftTeams` module:
+
+```PowerShell
+Install-Module -Name "MicrosoftTeams" -MinimumVersion 2.0.0
+Connect-MicrosoftTeams
+```
+
+To enable the view-only experience, you can use the following PowerShell snippet.
 
 ```PowerShell
 Set-CsTeamsMeetingPolicy -Identity Global -StreamingAttendeeMode Enabled

--- a/Teams/view-only-meeting-experience.md
+++ b/Teams/view-only-meeting-experience.md
@@ -48,7 +48,7 @@ Install-Module -Name "MicrosoftTeams" -MinimumVersion 2.0.0
 Connect-MicrosoftTeams
 ```
 
-To enable the view-only experience, you can use the following PowerShell snippet.
+To enable the view-only experience, you can use the following PowerShell snippet:
 
 ```PowerShell
 Set-CsTeamsMeetingPolicy -Identity Global -StreamingAttendeeMode Enabled

--- a/Teams/view-only-meeting-experience.md
+++ b/Teams/view-only-meeting-experience.md
@@ -39,7 +39,7 @@ Attendees will be able to join the view-only experience through desktop, web, an
 
 ## Teams view-only experience controls
 
-You enable the view-only experience using the [`Set-CsTeamsMeetingPolicy`](https://docs.microsoft.com/en-us/powershell/module/skype/set-csteamsmeetingpolicy?view=skype-ps) cmdlet from the [SkypeForBusiness PowerShell module](https://docs.microsoft.com/en-us/powershell/module/skype/?view=skype-ps) or at least version 2.0.0 of the [MicrosoftTeams module](https://www.powershellgallery.com/packages/MicrosoftTeams).
+You enable the view-only experience using the [`Set-CsTeamsMeetingPolicy`](https://docs.microsoft.com/powershell/module/skype/set-csteamsmeetingpolicy?view=skype-ps) cmdlet from the [SkypeForBusiness PowerShell module](https://docs.microsoft.com/powershell/module/skype/?view=skype-ps) or at least version 2.0.0 of the [MicrosoftTeams module](https://www.powershellgallery.com/packages/MicrosoftTeams).
 
 To use the recommended `MicrosoftTeams` module:
 


### PR DESCRIPTION
As the PowerShell snippet provided did not clarify which module to use, I've added further detail to explain this. The `MicrosoftTeams` module appears to lack any docs.microsoft.com documentation, so only a PowerShell Gallery link has been able to be provided, or the legacy link to the `SkypeForBusiness` module's documentation. I recommend whoever from Microsoft picks this up checks why there is no documentation for the `MicrosoftTeams` module; all hits for the cmdlet listed in this page bring up the legacy `SkypeForBusiness` module, which even itself talks about it having been deprecated with no links to the replacement module...