### PR TITLE
Adding carrier return

### DIFF
--- a/Teams/Exchange-Teams-interact.md
+++ b/Teams/Exchange-Teams-interact.md
@@ -60,6 +60,7 @@ The following table provides a helpful quick reference to feature availability b
 <sup>6</sup> Only contacts in default contacts folder. Access to other contacts folders or sub-folders is not supported.
 
 <sup>7</sup> Teams honors the [Outlook on the web mailbox policy](/powershell/module/exchange/client-access/set-owamailboxpolicy) setting that's configured by tenant admins to control whether users can change their profile picture. If the **-SetPhotoEnabled** setting is turned off in the policy, users cannot add, change, or remove their profile picture, so the porfile picture wont be synced to teams if the admin changes the photo.
+
 <sup>8</sup> You need to meet the requirements listed in the [Requirements to create and view meetings for mailboxes hosted on-premises](#requirements-to-create-and-view-meetings-for-mailboxes-hosted-on-premises) section.
 
 <sup>9</sup> A minimum of an Exchange Online Plan 1 license is also required. For more information, see [Search for Teams chat data for on-premises users](/microsoft-365/compliance/search-cloud-based-mailboxes-for-on-premises-users).


### PR DESCRIPTION
closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/6948

if the carrier return is not there, footnote 7 and 8 are in the same paragraph.