### PR TITLE
Update hardware-requirements-for-the-teams-app.md

### DIFF
--- a/Teams/hardware-requirements-for-the-teams-app.md
+++ b/Teams/hardware-requirements-for-the-teams-app.md
@@ -35,7 +35,7 @@ All of the requirements in the following sections apply to both the Microsoft Te
 |Hard disk    | 3.0 GB of available disk space        |
 |Display    |   1024 x 768 screen resolution |
 |Graphics hardware |  Windows OS: Graphics hardware acceleration requires DirectX 9 or later, with WDDM 2.0 or higher for Windows 10 (or WDDM 1.3 or higher for Windows 10 Fall Creators Update)
-|Operating system  |    Windows 10, Windows 10 on ARM, Windows 8.1, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2|
+|Operating system  |    Windows 10, Windows 10 on ARM, Windows 8.1, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2. Note: We recommend being on the latest OS version build available for windows and security patches.|
 |.NET version    |  Requires .NET 4.5 CLR or later       |
 |Video    |  USB 2.0 video camera       |
 |Devices    |   Standard laptop camera, microphone, and speakers    |

--- a/Teams/hardware-requirements-for-the-teams-app.md
+++ b/Teams/hardware-requirements-for-the-teams-app.md
@@ -35,7 +35,7 @@ All of the requirements in the following sections apply to both the Microsoft Te
 |Hard disk    | 3.0 GB of available disk space        |
 |Display    |   1024 x 768 screen resolution |
 |Graphics hardware |  Windows OS: Graphics hardware acceleration requires DirectX 9 or later, with WDDM 2.0 or higher for Windows 10 (or WDDM 1.3 or higher for Windows 10 Fall Creators Update)
-|Operating system  |    Windows 10, Windows 10 on ARM, Windows 8.1, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2. Note: We recommend being on the latest OS version build available for windows and security patches.|
+|Operating system  |    Windows 10, Windows 10 on ARM, Windows 8.1, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2. Note: We recommend using the latest Windows version and security patches available.|
 |.NET version    |  Requires .NET 4.5 CLR or later       |
 |Video    |  USB 2.0 video camera       |
 |Devices    |   Standard laptop camera, microphone, and speakers    |


### PR DESCRIPTION
At line 38 added some suggested language re OS and older builds.  I am not exactly sure what to say - but we want to include something like Windows 10 and 1803 is not recommended.  See ICM: 236372082  where cx video still on bc leave of a issue and tied to OS.  We want something similar to what Mac is saying on line 53 for supported versions and  how we say similar for mobile clients on line 90.