### PR TITLE
Clarifying what happens to recordings when SP or OD is full

### DIFF
--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -186,7 +186,7 @@ See [How to auto-apply a retention label](/microsoft-365/compliance/apply-retent
 
 See [Which policy takes precedence?](./assign-policies.md#which-policy-takes-precedence).
 
-**Where does the recording go if the user doesn't have OneDrive for Business or SharePoint?**
+**Where does the recording go if the user doesn't have OneDrive for Business or SharePoint, or the storage quota is full?**
 
 The recording will land in our temporary storage location where it will be held for 21 days. During that time, the organizer must download the recording. If not downloaded within 21 days, the recording is deleted.
 


### PR DESCRIPTION
Updating FAQ around what happens when a sharepoint site or users onedrive storage quota is full.