### PR TITLE
Removed wrong sentence about more that 3-months-old clients in teams-client-update.md

### DIFF
--- a/Teams/teams-client-update.md
+++ b/Teams/teams-client-update.md
@@ -54,8 +54,6 @@ As a modern online service, the Teams client auto-updates every two weeks. Becau
 
 To identify when desktop clients fall out of date, an in-app alert will be displayed if the user’s current version is between one and three months old, and if there's a new version available. This in-app messaging encourages users to update to the latest version of Teams or, if necessary, to reach out to their IT admin to do so. Users on Teams desktop clients that are more than three months old will see a blocking page that gives the options to update now, reach out to their IT admin, or continue to Teams on the web.
 
-Desktop client versions that are more than three months old upon first install and/or first run of Teams have a 28-day grace period before encountering the above-mentioned servicing information. During this period, the auto-update process will update the Teams client. If not updated, users will see an in-app alert encouraging them to manually update to the latest version of Teams. The users might be prompted to contact their IT admin to do the update. This includes users using the Teams desktop client as part of the Microsoft 365 Apps for enterprise bundle.
-
 Teams desktop clients on Government Clouds currently have an exception to this servicing agreement until further notice.
 
 For information on new version releases, check [Message Center](https://admin.microsoft.com/AdminPortal/Home#/MessageCenter) or go to **Help** > **What’s new** in the client.


### PR DESCRIPTION
I tested and:
![image](https://user-images.githubusercontent.com/33589238/118263041-0a9c6000-b4b6-11eb-87a6-81db5f09539b.png)

Related to https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/pull/7098.