### PR TITLE
add cvi coordinates to expired meetings

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -134,7 +134,7 @@ Channel names also can't start with an underscore (_) or period (.), or end with
 ### Meeting expiration
 
 > [!NOTE]
-> A meeting URL will never stop working. The expiry only relates to any PSTN dial-in numbers, CVI coordinates and/or underlying meeting policies and settings.
+> A meeting URL will never stop working. The expiry only relates to any PSTN dial-in numbers, CVI coordinates, and/or underlying meeting policies and settings.
 
 |Meeting type  |Meeting expires after this much time  |Each time you start or update a meeting, expiration extends by this much time  |
 |---------|---------|---------|

--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -134,7 +134,7 @@ Channel names also can't start with an underscore (_) or period (.), or end with
 ### Meeting expiration
 
 > [!NOTE]
-> A meeting URL will never stop working. The expiry only relates to any PSTN dial-in numbers and/or underlying meeting policies and settings.
+> A meeting URL will never stop working. The expiry only relates to any PSTN dial-in numbers, CVI coordinates and/or underlying meeting policies and settings.
 
 |Meeting type  |Meeting expires after this much time  |Each time you start or update a meeting, expiration extends by this much time  |
 |---------|---------|---------|


### PR DESCRIPTION
CVI coordinates will not work for expired Teams meetings, same as PSTN numbers. We need to clarify this to customers.
