### PR TITLE
Update teams-for-vdi.md

### DIFF
--- a/Teams/teams-for-vdi.md
+++ b/Teams/teams-for-vdi.md
@@ -179,6 +179,11 @@ To learn more about Teams and Microsoft 365 Apps for enterprise, see [How to exc
     - Per-machine installation
 
         ```console
+        reg add "HKLM\SOFTWARE\Microsoft\Teams" /v IsWVDEnvironment /t REG_DWORD /d 1 /f
+        ```
+        This process adds a required regkey to the machine that lets the Teams installer know it is a VDI instance.  Without it, the installer will error out, stating:  "Installation has failed.  Cannot install for all users when a VDI environment is not detected."
+
+        ```console
         msiexec /i <path_to_msi> /l*v <install_logfile_name> ALLUSER=1 ALLUSERS=1
         ```
 

--- a/Teams/teams-for-vdi.md
+++ b/Teams/teams-for-vdi.md
@@ -181,7 +181,7 @@ To learn more about Teams and Microsoft 365 Apps for enterprise, see [How to exc
         ```console
         reg add "HKLM\SOFTWARE\Microsoft\Teams" /v IsWVDEnvironment /t REG_DWORD /d 1 /f
         ```
-        This process adds a required regkey to the machine that lets the Teams installer know it is a VDI instance.  Without it, the installer will error out, stating:  "Installation has failed.  Cannot install for all users when a VDI environment is not detected."
+        This process adds a required registry key to the machine that lets the Teams installer know it is a VDI instance.  Without it, the installer will error out, stating: "Installation has failed.  Cannot install for all users when a VDI environment is not detected."
 
         ```console
         msiexec /i <path_to_msi> /l*v <install_logfile_name> ALLUSER=1 ALLUSERS=1


### PR DESCRIPTION
The regkey is required for per-machine installations, otherwise the included error will appear.

Fix found here:  https://techcommunity.microsoft.com/t5/windows-virtual-desktop/how-to-install-teams-in-wvd/m-p/1302404/highlight/true#M3476

Verified today, 5/20, on 20h1-evd-o365pp Marketplace image.