### PR TITLE
Update communicate-with-users-from-other-organizations.md

### DIFF
--- a/Teams/communicate-with-users-from-other-organizations.md
+++ b/Teams/communicate-with-users-from-other-organizations.md
@@ -35,7 +35,7 @@ Set up external access if you need to find, call, chat, and set up meetings with
 
 By default, external access is enabled for all domains. You can restrict external access by allowing or blocking specific domains or by turning it off.
 
-![Screenshot of external access settings](media/external-access-federation-settings.png)
+![Screenshot of external access settings](media/external-access-federation-settings.png) - [SL: UPdate screenshot]
 
 To configure external access, see [Manage external access](manage-external-access.md). 
 


### PR DESCRIPTION
Update screenshot from External Access TAC page to include the following screenshot: Your Teams users can add apps when they host meetings or chats with other organizations, and they can use apps shared by external users when your users join meetings or chats hosted by other organizations. The data policies of the hosting user's organization, as well as the data sharing practices of the third-party apps shared by that user's organization, will be applied.