### PR TITLE
Fixed Giphy typo

### DIFF
--- a/Teams/messaging-policies-in-teams.md
+++ b/Teams/messaging-policies-in-teams.md
@@ -81,7 +81,7 @@ Here are the messaging policy settings that you can configure.
 
 - **Chat**  Turn this setting on if you want users in your organization to be able to use the Teams app to chat with other people.
 - **Use Giphys in conversations**  If you turn on Giphys, users can include Giphys in chat conversations with other people. Giphy is an online database and search engine that allows users to search for and share animated GIF files. Each Giphy is assigned a content rating. In addition to turning on this setting, you need to enable [Optional Connected Experiences](/deployoffice/privacy/manage-privacy-controls#policy-setting-for-optional-connected-experiences) to allow Giphys in conversations.
-- **Gipsy content rating**
+- **Giphy content rating**
     - **No restriction** This means that your users will be able to insert any Giphy in chats regardless of the content rating.
     - **Moderate**  This means that your users will be able to insert Giphys in chats, but will be moderately restricted from adult content.
     - **Strict**  This means that your users will be able to insert Giphys in chats, but will be strictly restricted from adult content.


### PR DESCRIPTION
Fixed typo where Giphy was written as Gipsy (reported in issue #7296 )