### PR TITLE
Update plan-for-government-gcc-high.md

### DIFF
--- a/Teams/plan-for-government-gcc-high.md
+++ b/Teams/plan-for-government-gcc-high.md
@@ -86,6 +86,3 @@ Determine your requirements for governance and how you can meet them. Go to [Pla
 After you've been onboarded to Office 365 Government – GCC High, follow the recommended deployment path outlined in [How to roll out Microsoft Teams](./deploy-overview.md). Be sure to engage with your Adoption and Change Management team and Teams champions.
 
 You can also work with [FastTrack](https://www.microsoft.com/fasttrack) or your chosen partner to onboard the service.
-
-> [!NOTE]
-> The Mac Teams client for GCCH environments is not yet supported.


### PR DESCRIPTION
Mac support is being released, so deleting the note about its not being supported.