### PR TITLE
Update VDI public doc

### DIFF
--- a/Teams/teams-for-vdi.md
+++ b/Teams/teams-for-vdi.md
@@ -397,8 +397,7 @@ The following calling and meeting features are not supported:
 The following are known issues and limitations for calling and meetings:
 
 - Interoperability with Skype for Business is limited to audio calls; there is no video modality.
-- Only a single incoming video stream is supported in meetings or group calls. When multiple people send video, only the dominant speaker's video is shown at any given time.
-- Incoming and outgoing video stream resolution is limited to 720p resolution. This is a WebRTC limitation.
+- Incoming and outgoing video stream resolution is limited to 720p resolution.
 - Only one video stream from an incoming camera or screen share stream is supported. When there's an incoming screen share, that screen share is shown, instead of the video of the dominant speaker.
 - Teams doesn't switch to use the last audio device that a user selected, if the device is disconnected, and then reconnected.
 - Outgoing screen sharing:


### PR DESCRIPTION
1. After 2x2, 4 incoming videos are supported.
2. 720p resolution limitation is no longer Webrtc limitation.