### PR TITLE
Updated copy and images

### DIFF
--- a/Teams/career-coach.md
+++ b/Teams/career-coach.md
@@ -105,7 +105,7 @@ Use the [Manage apps page](/microsoftteams/manage-apps) to view the Teams apps i
 
 4. Select **Career Coach**, and then select **Settings.**  
 
-    ![shows the Career Coach app selected with the Settings option showing](media/app-settings.png)
+    ![shows the Career Coach app selected with the Settings option showing](images/app-settings.png)
 
 ### Configure the Career Coach app settings
 
@@ -128,7 +128,7 @@ Career Coach has five configuration categories:
 
 Set your educational institution’s name, logo, and default language on the brand and preferences settings page.
 
-![the Career Coach branding section of the admin center](media/brand-preferences.png)
+![the Career Coach branding section of the admin center](images/brand-preferences.png)
 
 ##### Educational institution icon
 
@@ -167,7 +167,7 @@ Determine the educational institution's LinkedIn page. Find the LinkedIn page by
 
 4. Copy the verification URL and share it with your educational institution’s LinkedIn page admin [LinkedIn page admin documentation](https://www.linkedin.com/help/linkedin/answer/4783/linkedin-page-admins-overview?lang=en). The verification link expires after 30 days.  
 
-   ![linkedin settings for the career coach](media/linkedin.png)  
+   ![linkedin settings for the career coach](images/linkedin.png)  
 
 #### Course catalog
 
@@ -178,9 +178,6 @@ The course catalog represents the courses and classes offered to students by you
 - Courses and course meta data, like descriptions, are used to help students identify their skills when they upload a transcript.  
 
 To create the course catalog, put together a list of all courses taught at your educational institution and upload it as a CSV file. The app draws from the course catalog to identify a student’s skills from their transcript and to suggest courses to take. 
-
-> [!NOTE]
-> See [Location of data in Teams](location-of-data-in-teams.md) and [Security and compliance](security-compliance-overview.md) for information about protecting of student information. 
 
 ##### Course catalog documents formatting and schema
 
@@ -312,13 +309,9 @@ The following resources will help you plan your Career Coach app.
 
 - [Managing apps in Microsoft Teams Admin Center](manage-apps.md)
 
-- [Security, privacy, and compliance in Microsoft Teams](security-compliance-overview.md)
-
 - [Online Virtual Orientation Kit](https://www.microsoft.com/education/remote-learning/virtual-orientation) 
 
 - [Limits and specification of Teams channels](limits-specifications-teams.md)
-
-- [Location of data in Microsoft Teams](location-of-data-in-teams.md)
 
 - [Getting started with admin training for Microsoft Teams](ITAdmin-readiness.md)
 


### PR DESCRIPTION
1. Access the Career Coach app settings – Need to update visual (https://github.com/afilosa/OfficeDocs-SkypeForBusiness) to remove to white out the “Update/Delete” and “Publish status”. These elements come for a LOB/ Custom app but not for our MSFT app. Perhaps you will need help from Jason or D to get the updated visual.
2. Brand – update screenshot (https://github.com/afilosa/OfficeDocs-SkypeForBusiness)
3. LinkedIn connection – update screenshot (https://github.com/afilosa/OfficeDocs-SkypeForBusiness)
4. Remove location of data and security/compliance Note (below) and Resources links at the bottom of the page since these are not relevant for Career Coach. Specific documentation for these topics needs to get prioritized to include in documentation – we’re already in touch on this.