### PR TITLE
Updating to support mfa

### DIFF
--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -81,8 +81,7 @@ The meeting recording option is a setting at the Teams policy level. The followi
    # When using Teams PowerShell Module
    
    Import-Module MicrosoftTeams
-   $credential = Get-Credential
-   Connect-MicrosoftTeams -Credential $credential
+   Connect-MicrosoftTeams
    ```
 
 5. Use [Set-CsTeamsMeetingPolicy](/powershell/module/skype/set-csteamsmeetingpolicy) to set a Teams Meeting Policy to transition from the Stream storage to OneDrive for Business and SharePoint.


### PR DESCRIPTION
In the current module version as of today (`2.3.1`) only way to connect supporting MFA is without specifying credentials, which forces the login prompt. As it is encouraged to use MFA, updating here.

Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/7337