### PR TITLE
Teams Meeting limit

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -115,7 +115,8 @@ Channel names also can't start with an underscore (_) or period (.), or end with
 
 |Feature     | Maximum limit |
 |------------|---------------|
-|Number of people in a meeting (can chat and call in)  | 1000, includes GCC but not yet for GCCH, DoD, or A1 (300). **View-only** allows for up to 20,000 listen-only participants to join a meeting in which the organizer has a license for E3/E5/A3/A5 SKU, as well as, Government (GCC, GCC High, DoD). Learn more about the [View-only experience](view-only-meeting-experience.md).|
+|Number of people in a meeting (can chat and call in) <br> Organizer with E3/E5/A3/A5 SKU  | 1000, includes GCC but not yet for GCCH, DoD, or A1 (300). **View-only** allows for up to 20,000 listen-only participants to join a meeting in which the organizer has a license for E3/E5/A3/A5 SKU, as well as, Government (GCC, GCC High, DoD). Learn more about the [View-only experience](view-only-meeting-experience.md).|
+|Number of people in a meeting (can chat and call in) <br> Organizer without E3/E5/A3/A5 SKU | 300 |
 |Number of people in a video or audio call from chat | 20 |
 |Max PowerPoint File Size | 2GB|
 |Teams keeps [meeting recordings](cloud-recording.md) that don't get uploaded to Microsoft Stream, available for local download | 20 days |


### PR DESCRIPTION
Till end of CY21 irrespective of license any user can create a 1000 participant meeting. After Dec CY21 only E3/E5/A3/A5 SKU are allowed to create 1000 participant meeting and other sku limit will be 300