### PR TITLE
Exchange requirements

### DIFF
--- a/Teams/rooms/requirements.md
+++ b/Teams/rooms/requirements.md
@@ -36,6 +36,7 @@ Refer to:
 > Earlier platforms like Lync Server 2013 are not supported by Microsoft Teams Rooms. Microsoft Teams Rooms is not supported in Microsoft 365 or Office 365 operated by 21Vianet, or DoD environments.
 >
 > If you have an on-prem Exchange server, Microsoft Teams Rooms requires the use of Exchange Server 2013 SP1 or later.
+> https://docs.microsoft.com/en-us/microsoftteams/rooms/rooms-authentication 
 
 ## Hardware requirements
 A hardware deployment includes a selection of a Microsoft Teams Room system, combined with certified audio and video peripherals, and a cabling solution to integrate these devices together.  These options are described here.


### PR DESCRIPTION
On line 38 it says that  "Microsoft Teams Rooms requires the use of Exchange Server 2013 SP1 or later"

On article https://docs.microsoft.com/en-us/microsoftteams/rooms/rooms-authentication 
Under prerequisites it says "You must have Exchange Server 2016 CU8 or later, or Exchange Server 2019 CU1 or later."

What is the correct one ?