### PR TITLE
Update call-park-and-retrieve.md

### DIFF
--- a/Teams/call-park-and-retrieve.md
+++ b/Teams/call-park-and-retrieve.md
@@ -42,7 +42,7 @@ To park and retrieve calls, a user must be an Enterprise Voice user and must be 
 
 You must be a Teams admin to configure call park and retrieve. It is disabled by default. You can enable it for users and create user groups using the call park policy. When you apply the same policy to a set of users, they can park and retrieve calls among themselves.
 
-The range of call pickup numbers is predefined to be from 10-99 and cannot be modified.  The first parked call will be rendered a pickup code of 10, the next parked call will be rendered a pickup code of 11, etc. until 99 is rendered as a pickup code. After which, the rendered pickup codes start over from 10 once again.  If there are more than 89 active parked calls, the rendered pickup codes will keep incrementing beyond 99 such that the 90th active call would be rendered 100 for a pickup code, the 90th active parked call would be rendered a pickup code of 101.
+The range of call pickup numbers is predefined to be from 10-99 and cannot be modified. The first parked call will be rendered a pickup code of 10, the next parked call will be rendered a pickup code of 11, etc. until 99 is rendered as a pickup code. After which, the rendered pickup codes start over from 10 once again.  If there are more than 89 active parked calls, the rendered pickup codes will keep incrementing beyond 99 such that the 90th active parked call would be rendered 100 for a pickup code, the 91st active parked call would be rendered a pickup code of 101.
 
 To enable a call park policy
 

--- a/Teams/call-park-and-retrieve.md
+++ b/Teams/call-park-and-retrieve.md
@@ -42,6 +42,8 @@ To park and retrieve calls, a user must be an Enterprise Voice user and must be 
 
 You must be a Teams admin to configure call park and retrieve. It is disabled by default. You can enable it for users and create user groups using the call park policy. When you apply the same policy to a set of users, they can park and retrieve calls among themselves.
 
+The range of call pickup numbers is predefined to be from 10-99 and cannot be modified.  The first parked call will be rendered a pickup code of 10, the next parked call will be rendered a pickup code of 11, etc. until 99 is rendered as a pickup code. After which, the rendered pickup codes start over from 10 once again.  If there are more than 89 active parked calls, the rendered pickup codes will keep incrementing beyond 99 such that the 90th active call would be rendered 100 for a pickup code, the 90th active parked call would be rendered a pickup code of 101.
+
 To enable a call park policy
 
 1. In the left navigation of the Microsoft Teams admin center, go to **Voice** > **Call park policies**.


### PR DESCRIPTION
Added the following description of pickup ranges to avoid customer inquiries:

The range of call pickup numbers is predefined to be from 10-99 and cannot be modified.  The first parked call will be rendered a pickup code of 10, the next parked call will be rendered a pickup code of 11, etc. until 99 is rendered as a pickup code. After which, the rendered pickup codes start over from 10 once again.  If there are more than 89 active parked calls, the rendered pickup codes will keep incrementing beyond 99 such that the 90th active call would be rendered 100 for a pickup code, the 90th active parked call would be rendered a pickup code of 101.