### PR TITLE
Revert PR#6839 (coexistence-chat-calls-presence.md)

### DIFF
--- a/Teams/coexistence-chat-calls-presence.md
+++ b/Teams/coexistence-chat-calls-presence.md
@@ -75,7 +75,7 @@ In the tables that follow:
 
 | <br/><br/> Mode | Originator <br/><br/> Client | <br/><br/> SfB&nbsp;homed |<br/><br/>Route-->| Recipient <br/><br/> Islands  |
 |--- |--- |--- |--- |--- |
-| Islands | Teams <br/> Skype for Business<br/> Teams<br/> Skype for Business| Online<br/> Online<br/> On-prem<br/>On-prem| &boxv;<br/>&boxv;<br/>&boxv;<br/>&boxv;|Teams <br/> Skype for Business<br/> **Not Possible**<br/> Skype for Business|
+| Islands | Teams <br/> Skype for Business<br/> Teams<br/> Skype for Business| Online<br/> Online<br/> On-prem<br/>On-prem| &boxv;<br/>&boxv;<br/>&boxv;<br/>&boxv;|Teams <br/> Skype for Business<br/> Teams<br/> Skype for Business|
 |SfB\* <br/> | Skype for Business<br/>Skype for Business<br/> | Online<br/> On-prem<br/> |&boxv;<br/>&boxv;|Skype for Business<br/>Skype for Business<br/>|
 |TeamsOnly |Teams| Online<br/>|&boxv;<br/>|Teams|
 | | | | | |
@@ -93,7 +93,7 @@ In the tables that follow:
 
 | <br/><br/> Mode   | Originator <br/><br/> Client | <br/><br/> SfB&nbsp;homed |<br/><br/>Route-->|   Recipient <br/><br/> TeamsOnly  |
 |--- |--- |--- |--- | --- |
-| Islands   |Teams<br/>Skype for Business<br/>Teams <br/>Skype for Business<br/>|Online<br/> Online<br/> On-prem<br/> On-prem<br/>  | &boxv;<br/>&boxv;<br/>&boxv;<br/>&boxv;|  Teams <br/>*Teams* <br/>**Not Possible** <br/>*Teams*  |
+| Islands   |Teams<br/>Skype for Business<br/>Teams <br/>Skype for Business<br/>|Online<br/> Online<br/> On-prem<br/> On-prem<br/>  | &boxv;<br/>&boxv;<br/>&boxv;<br/>&boxv;|  Teams <br/>*Teams* <br/>Teams <br/>*Teams*  |
 |SfB\*  | Skype for Business<br/>Skype for Business<br/> | Online<br/> On-prem<br/> | &boxv;<br/>&boxv; | *Teams*  <br/>*Teams*   |
 |TeamsOnly  | Teams | Online |  &boxv; |Teams   |
 |  |  |  | | |


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/7434.

I agree with the author of this issue. I think the following PR was not correct:
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/pull/6839

The following sentence is talking about in-tenant interoperability and federation:
"If the Skype for Business account of the originator is homed on-premises, that user can't use the Teams client for in-tenant interoperability or for federation. That user can only use the Skype for Business client for interoperability and federation."
If an sfb user is homed on-premises and upgrade mode is Island, he can't use the Teams client to communicate with an in-tenant SfBO user (SfB* upgrade mode) or federated user.

The tables show routing in all scenarios, not just interoperability.

@RuiPereiraTabares @bjwhalen @jambirk @cichur, maybe you can kindly share your thoughts here. Thank you so much!