### PR TITLE
Add recommendation for 32/64-bit version

### DIFF
--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -56,7 +56,7 @@ IT admins can choose their preferred method to distribute the installation files
 The Microsoft Teams installation for Windows provides downloadable installers in 32-bit and 64-bit architecture.
 
 > [!NOTE]
-> The architecture (32-bit vs. 64-bit) of Microsoft Teams is agnostic to the architecture of Windows and Office that is installed.
+> The architecture (32-bit vs. 64-bit) of Microsoft Teams is agnostic to the architecture of Windows and Office that is installed. It is recommended to prefer the 64-bit version of Microsoft Teams.
 
 The Windows client is deployed to the AppData folder located in the user’s profile. Deploying to the user’s local profile allows the client to be installed without requiring elevated rights. The Windows client leverages the following locations:
 

--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -56,7 +56,7 @@ IT admins can choose their preferred method to distribute the installation files
 The Microsoft Teams installation for Windows provides downloadable installers in 32-bit and 64-bit architecture.
 
 > [!NOTE]
-> The architecture (32-bit vs. 64-bit) of Microsoft Teams is agnostic to the architecture of Windows and Office that is installed. It is recommended to prefer the 64-bit version of Microsoft Teams.
+> The architecture (32-bit vs. 64-bit) of Microsoft Teams is agnostic to the architecture of Windows and Office that is installed. We recommended the 64-bit version of Microsoft Teams.
 
 The Windows client is deployed to the AppData folder located in the user’s profile. Deploying to the user’s local profile allows the client to be installed without requiring elevated rights. The Windows client leverages the following locations:
 

--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -56,7 +56,7 @@ IT admins can choose their preferred method to distribute the installation files
 The Microsoft Teams installation for Windows provides downloadable installers in 32-bit and 64-bit architecture.
 
 > [!NOTE]
-> The architecture (32-bit vs. 64-bit) of Microsoft Teams is agnostic to the architecture of Windows and Office that is installed. We recommended the 64-bit version of Microsoft Teams.
+> The architecture (32-bit vs. 64-bit) of Microsoft Teams is agnostic to the architecture of Windows and Office that is installed. We recommend the 64-bit version of Microsoft Teams on 64-bit systems.
 
 The Windows client is deployed to the AppData folder located in the user’s profile. Deploying to the user’s local profile allows the client to be installed without requiring elevated rights. The Windows client leverages the following locations:
 


### PR DESCRIPTION
I would suggest to add a recommendation for the 64-bit version of Teams on Windows. If you install the 32-bit version, a banner is displayed in the Teams client telling the user that it is recommended to use the 64-bit version. So we should also add this recommendation to this Docs article.