### PR TITLE
select-rule wrong image

### DIFF
--- a/Teams/alerts/device-health-status.md
+++ b/Teams/alerts/device-health-status.md
@@ -28,7 +28,7 @@ Before you start, you'll need the teams/channel creation permissions in your ten
 
 1. In the left navigation of the Microsoft Teams admin center, select **Notifications & alerts** > **Rules**.
 
-   ![Rules section in admin center](../media/select-rules.png)
+   ![Rules section in admin center]
 
 2. In the **Rules** Page, select **Device state rule**.
 


### PR DESCRIPTION
The image "select-rules.png" is wrong and should be changed. The option "setting" is not available anymore for customers. 
I have a case where the customer is complaining why the option is not available.