### PR TITLE
Update rooms-lifecycle-support.md

### DIFF
--- a/Teams/rooms/rooms-lifecycle-support.md
+++ b/Teams/rooms/rooms-lifecycle-support.md
@@ -68,10 +68,6 @@ When you use a supported version of Windows 10, you will always get the latest a
 > 
 > The devices with compatiablity issues are:
 > 
-> - HP Elite Slice
-> - HP Elite Slice G2 MS SRS Audio Ready
-> - HP Elite Slice MS SRS Partner Ready
-> - HP Elite Slice G2 with MS MTR
 > - Crestron UC-Engine (BIOS version/date contains "KYSKLI" - indicating a Skull Canyon BIOS) 
 
 ## Related topics


### PR DESCRIPTION
Window compat team just confirmed that they removed 20h2 upgrade block for HP Slice.