### PR TITLE
Removing legacy CQD references

### DIFF
--- a/Teams/CQD-frequently-asked-questions.md
+++ b/Teams/CQD-frequently-asked-questions.md
@@ -31,8 +31,6 @@ description: Read frequently asked questions (FAQ) and answers about Microsoft T
 
 [Why do I see up to 0.2% difference in call and user count values on measures and how to get most accurate volumes? ](#why-do-i-see-up-to-02-difference-in-call-and-user-count-values-on-measures-and-how-to-get-most-accurate-volumes)
 
-[Why is CQD data from Skype for Business different than CQD data from Teams? ](#why-is-cqd-data-from-skype-for-business-different-than-cqd-data-from-teams)
-
 [Why can't I see EUII in CQD?](#why-cant-i-see-euii-in-cqd)
 
 [Why am I seeing Skype for Business information in CQD when I've filtered for Teams only?](#why-am-i-seeing-skype-for-business-information-in-cqd-when-ive-filtered-for-teams-only)
@@ -69,17 +67,6 @@ The telemetry will not necessarily call out the issue, but it can help you bette
 
 ### Why do I see up to 0.2% difference in call and user count values on measures and how to get most accurate volumes? 
 To compute call count and user count measures, a distinct countif operation is performed against the call or user identifiers in the data set. On large data sets, there is an up to 0.2% error inherent with the distinct countif operation. For the most accurate volume, you should rely on stream count measures since they do not rely on this distinct countif operation. Filtering to reduce the data volume may reduce the error but may not eliminate this source of error in distinct call and user counts. Refer to [Dimensions and measurements available in Call Quality Dashboard](dimensions-and-measures-available-in-call-quality-dashboard.md) for which measures are impacted.
-
-
-### Why is CQD data from Skype for Business different than CQD data from Teams? 
-
-
-> [!IMPORTANT]
-> As of July 1, 2020, the older CQD (CQD.lync.com) uses data from the latest CQD (CQD.Teams.microsoft.com). The older CQD data is no longer available, and you can't export your building or report data. You can still use CQD.lync.com (available from the Skype for Business admin center), but we'll turn off access to CQD.lync.com soon, so you should move to CQD.Teams.microsoft.com if you haven't already done so.
-
-
-If you're trying to compare data between the older CQD from the Skype for Business legacy portal (cqd.lync.com) and the latest CQD from the Teams admin center (cqd.teams.microsoft.com), you'll quickly notice that the data doesn't match. That's because the latest CQD reports on many additional calling scenarios. If you're still using reports from the older CQD, use this article to help you interpret those reports: [Call Quality Dashboard for Skype for Business Server](/skypeforbusiness/management-tools/call-quality-dashboard/call-quality-dashboard).
-
 
   
 ### Why can't I see EUII in CQD?


### PR DESCRIPTION
CQD v2 retired July 31, removing legacy references