### PR TITLE
Fix the powershell code snipped

### DIFF
--- a/Teams/google-workspace-addon-teams.md
+++ b/Teams/google-workspace-addon-teams.md
@@ -59,12 +59,12 @@ $servicePrincipal = Get-AzureADServicePrincipal -Filter "appId eq '$appId'"
 if ($servicePrincipal) {
     # Service principal exists already, disable it
     Set-AzureADServicePrincipal -ObjectId $servicePrincipal.ObjectId -AccountEnabled $false
-    Write-Host "Disabled existing Service Principal \n"
+    Write-Host "Disabled existing Service Principal `n"
 } else {
     # Service principal does not yet exist, create it and disable it at the same time
-    New-AzureADServicePrincipal -AppId $appId -DisplayName $displayName
-    $servicePrincipal = New-AzureADServicePrincipal -AppId $appId -DisplayName $displayName -AccountEnabled $false
-    Write-Host "Created and disabled the Service Principal \n"
+    $servicePrincipal=New-AzureADServicePrincipal -AppId $appId -DisplayName $displayName
+    Set-AzureADServicePrincipal -ObjectId $servicePrincipal.ObjectId -AccountEnabled $false
+    Write-Host "Created and disabled the Service Principal `n"
 }
 ```
 


### PR DESCRIPTION
I tested using `$servicePrincipal = New-AzureADServicePrincipal -AppId $appId -DisplayName $displayName -AccountEnabled $false` instead, but `-AccountEnabled $false` did not get assigned, so would have to use `Set-AzureADServicePrincipal` after the creation.