### PR TITLE
Update direct-routing-plan-media-bypass.md

### DIFF
--- a/Teams/direct-routing-plan-media-bypass.md
+++ b/Teams/direct-routing-plan-media-bypass.md
@@ -252,8 +252,8 @@ The client must have access to the specified ports (see table) on the public IP 
 
 | Traffic | From | To | Source port | Destination port|
 | :-------- | :-------- |:-----------|:--------|:---------|
-UDP/SRTP | Client | SBC | 3478-3481 and 49152 – 53247| Defined on the SBC |
-| UDP/SRTP | SBC | Client | Defined on the SBC | 3478-3481 and 49152 – 53247  |
+UDP/SRTP | Client | SBC | (By default) 50000 – 50019 | Defined on the SBC |
+| UDP/SRTP | SBC | Client | Defined on the SBC | (By default) 50000 – 50019 |
 
 
 > [!NOTE]


### PR DESCRIPTION
In Media Bypass environment client reaches directly SBC public IP using its media port define in the meeting settings (by default 50 000 to 50 019)