### PR TITLE
Adding related topic

### DIFF
--- a/Teams/meeting-policies-in-teams.md
+++ b/Teams/meeting-policies-in-teams.md
@@ -575,3 +575,4 @@ Meeting reactions are Off by default. Turning off reactions for a user doesn't m
 - [Teams PowerShell overview](teams-powershell-overview.md)
 - [Assign policies to your users in Teams](assign-policies.md)
 - [Remove the RestrictedAnonymousAccess Teams meeting policy from users](meeting-policies-restricted-anonymous-access.md)
+- [Set up for webinars in Microsoft Teams](set-up-webinars.md)


### PR DESCRIPTION
As these policies are part of the General section:

_Allow engagement report
Allow meeting registration
Who can register_

and we can find them in the article I am adding, it would be good to include a link

closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/7741