### PR TITLE
Prevent potentially fraudulent sites

### DIFF
--- a/Teams/rooms/third-party-join.md
+++ b/Teams/rooms/third-party-join.md
@@ -57,8 +57,8 @@ To add third-party meeting service URLs to the ATP Safe Links "do not rewrite" l
 
 Here are some example entries that you may need to add to your ATP Safe Links "do not rewrite" list or third-party URL rewrite exception list:
 
-- **Cisco WebEx** `*.webex.com*`
-- **Zoom** `*.zoom.us*`, `*.zoom.com*`, `*.zoomgov.com*`
+- **Cisco WebEx** `*.webex.com/*`
+- **Zoom** `*.zoom.us/*`, `*.zoom.com/*`, `*.zoomgov.com/*`
 
 For a complete list of URLs to add to your ATP Safe Links "do not rewrite" list or third-party URL rewrite exception list, contact the third-party meeting service provider you want to accept meeting invites from. 
 


### PR DESCRIPTION
Added a trailing slash before the final wildcard.

Per Microsoft documentation, having `*contoso.com/*` is inherently better than `*contoso.com*` because it doesn't allow potentially fraudulent sites.

Reference: https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-links?view=o365-worldwide#entry-syntax-for-the-do-not-rewrite-the-following-urls-list