### PR TITLE
Update direct-routing-enable-users.md

### DIFF
--- a/Teams/direct-routing-enable-users.md
+++ b/Teams/direct-routing-enable-users.md
@@ -100,7 +100,7 @@ After you have created the user and assigned a license, the next step is to conf
     Set-CsUser -Identity "<User name>" -EnterpriseVoiceEnabled $true -HostedVoiceMail $true -OnPremLineURI tel:<phone number>
     ```
     > [!NOTE]
-    > By executing this cmdlet successfully to configure the user's phone number for Direct Routing, will be set OnPremLineUriManuallySet to True.
+    > By executing this cmdlet successfully to configure the user's phone number for Direct Routing, OnPremLineUriManuallySet will be set to True.
 
     For example, to add a phone number for user "Spencer Low," enter the following: 
 

--- a/Teams/direct-routing-enable-users.md
+++ b/Teams/direct-routing-enable-users.md
@@ -75,7 +75,7 @@ Direct Routing requires the user to be homed online. You can check by looking at
 
    ```console
    RegistrarPool                        : pool.infra.lync.com
-   OnPremLineURIManuallySet             : True
+   OnPremLineURIManuallySet             : False
    OnPremLineURI                        : 
    LineURI                              : 
    ```
@@ -99,7 +99,9 @@ After you have created the user and assigned a license, the next step is to conf
     ```PowerShell
     Set-CsUser -Identity "<User name>" -EnterpriseVoiceEnabled $true -HostedVoiceMail $true -OnPremLineURI tel:<phone number>
     ```
-    
+    > [!NOTE]
+    > By executing this cmdlet successfully to configure the user's phone number for Direct Routing, will be set OnPremLineUriManuallySet to True.
+
     For example, to add a phone number for user "Spencer Low," enter the following: 
 
     ```PowerShell


### PR DESCRIPTION
There have been examples of admins confusing the required configuration with OnPremLineUriManuallySet: False where the article sets an expectaiton of True. The attribute is not modifiable manually and only setting OnPremLineUri tel:+xxxxxxxxxxx will set OnPremLineUriManuallySet: True.