### PR TITLE
Fixed maximum value for TMR expiration period

### DIFF
--- a/Teams/cloud-recording.md
+++ b/Teams/cloud-recording.md
@@ -308,7 +308,7 @@ Admins can change the default expiration setting in PowerShell or the Teams admi
 
 The expiration days value can be set as follows:
   
-- Value can be from 1 to 9,999.
+- Value can be from 1 to 99,999.
 - Value can also be -1 to set TMR to never expire. 
  
 Admins can't change the expiration date on existing TMRs already uploaded to OneDrive or SharePoint before this feature was released. This protects the intent of the user that owns the TMR.


### PR DESCRIPTION
fixes #8092 
The documentation states 9,999 as max value whereas the `Set-CsTeamsMeetingPolicy` cmdlet documentation of parameter `NewMeetingRecordingExpirationDays` states 99,999 as max value.

[Teams cloud meeting recording > Frequently asked questions](https://docs.microsoft.com/en-us/microsoftteams/cloud-recording#frequently-asked-questions)
> #### How can an admin change the expiration date?
> Admins can change the default expiration setting in PowerShell or the Teams admin center before the feature is released. 
> [...] 
>
> The expiration days value can be set as follows:
> - Value can be from 1 to **_9,999_**.
> - Value can also be -1 to set TMR to never expire.

[Set-CsTeamsMeetingPolicy > Parameters: NewMeetingRecordingExpirationDays](https://docs.microsoft.com/en-us/powershell/module/skype/set-csteamsmeetingpolicy?view=skype-ps#parameters)
-NewMeetingRecordingExpirationDays
Specifies the number of days before meeting recordings will expire and move to the recycle bin. Value can be from 1 to 99,999 days. Value can also be -1 to set meeting recordings to never expire.