### PR TITLE
Fix YouTube embed link

### DIFF
--- a/Teams/teams-adoption-understand-teams-and-channels.md
+++ b/Teams/teams-adoption-understand-teams-and-channels.md
@@ -37,7 +37,7 @@ To read more about teams and channels, see the [Overview of teams and channels i
 
 | &nbsp; |&nbsp;  |
 |---------|---------|
-| View this short video   | <iframe width="350" height="200" src="https://youtu.be/WkAVgNKn0hs" frameborder="0" allowfullscreen></iframe>   |
+| View this short video   | <iframe width="350" height="200" src="https://www.youtube.com/embed/WkAVgNKn0hs" frameborder="0" allowfullscreen></iframe>   |
 
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36666927/140521322-56409dd4-c39f-4e73-be61-14d7dcf99e9f.png)

the youtube link is currently giving this error

_Refused to display 'https://www.youtube.com/' in a frame because it set 'X-Frame-Options' to 'sameorigin'._

the URL must have embed instead

closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/8101