### PR TITLE
Update log-files.md

### DIFF
--- a/Teams/log-files.md
+++ b/Teams/log-files.md
@@ -138,7 +138,8 @@ The files will be available in ~/.config/Microsoft/Microsoft Teams/logs.txt.
 To collect logs for Windows:
 Click on the Microsoft Teams icon in your system tray, and select **Collect support files**.
 The logs.txt file will be opened in Notepad automatically.    
-When investigating problems logging into Teams you may need to manually collect the Desktop logs. These log files are located at %appdata%\Microsoft\Teams in Windows.
+
+When investigating problems signing into Teams, you might need to manually collect the desktop logs. These log files are located at %appdata%\Microsoft\Teams in Windows.
 
 ## Browser trace
 

--- a/Teams/log-files.md
+++ b/Teams/log-files.md
@@ -136,8 +136,9 @@ Click on the Microsoft Teams icon in your system tray, and select **Get Logs**.
 The files will be available in ~/.config/Microsoft/Microsoft Teams/logs.txt.
   
 To collect logs for Windows:
-Click on the Microsoft Teams icon in your system tray, and select **Get Logs**.
+Click on the Microsoft Teams icon in your system tray, and select **Collect support files**.
 The logs.txt file will be opened in Notepad automatically.    
+When investigating problems logging into Teams you may need to manually collect the Desktop logs. These log files are located at %appdata%\Microsoft\Teams in Windows.
 
 ## Browser trace
 


### PR DESCRIPTION
Update Windows option to get Desktop logs. Get Logs doesn't exist. Need to use option - Collect support files. Also, Desktop logs are useful for troubleshooting authentication or login issues. Collecting the Desktop log manually from %appdata%\Microsoft\Teams is a helpful step.