### PR TITLE
Update quick-start-meetings-live-events.md

### DIFF
--- a/Teams/quick-start-meetings-live-events.md
+++ b/Teams/quick-start-meetings-live-events.md
@@ -48,9 +48,9 @@ The following table briefly summarizes the three types of meetings, the number o
 | Live events | Up to 20,000** |-Broadcast to large audiences. <br>-Moderated Q&A for audience interaction. <br> -Can specify producers and presenters, including external presenters.<br>-Supports more advanced production capabilities. | No |
 ||||
 
-*The usual 10,000 is increased to 20,000 through December 31, 2021.<br>
+*The usual 10,000 is increased to 20,000 through June 30, 2022.<br>
 
-**The usual 10,000 is increased to 20,000 through December 31, 2021. You can schedule even greater numbers with live events in Yammer and/or Microsoft Stream. For more information, see [Live events across Microsoft 365](/stream/live-event-m365). Note that events over 20,000 attendees require the [Live Events Assistance Program](/stream/live-events-assistance). 
+**The usual 10,000 is increased to 20,000 through June 30, 2022. You can schedule even greater numbers with live events in Yammer and/or Microsoft Stream. For more information, see [Live events across Microsoft 365](/stream/live-event-m365). Note that events over 20,000 attendees require the [Live Events Assistance Program](/stream/live-events-assistance). 
 
 **Considerations for large meetings, webinars, and live events** - When hosting large meetings, consider the following:
 


### PR DESCRIPTION
Updating the Teams Live Event limit increases date to June 30, 2022.