### PR TITLE
Removed reference to sip-all.pstnhub.microsoft.com

### DIFF
--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -231,7 +231,7 @@ The FQDNs – sip.pstnhub.microsoft.com, sip2.pstnhub.microsoft.com and sip3.pst
 - 52.112.0.0/14
 - 52.120.0.0/14
 
-You need to open ports for all these IP address ranges in your firewall to allow incoming and outgoing traffic to and from the addresses for signaling.  If your firewall supports DNS names, the FQDN **sip-all.pstnhub.microsoft.com** resolves to all these IP subnets. 
+You need to open ports for all these IP address ranges in your firewall to allow incoming and outgoing traffic to and from the addresses for signaling.
 
 ### Office GCC DoD environment
 
@@ -255,7 +255,7 @@ The FQDN sip.pstnhub.gov.teams.microsoft.us will be resolved to an IP address fr
 
 - 52.127.88.0/21
 
-You need to open ports for all these IP addresses in your firewall to allow incoming and outgoing traffic to and from the addresses for signaling. If your firewall supports DNS names, the FQDN **sip-all.pstnhub.gov.teams.microsoft.us** resolves to all these IP addresses. This FQDN can also be used as Federated FQDN for inbound call classification.
+You need to open ports for all these IP addresses in your firewall to allow incoming and outgoing traffic to and from the addresses for signaling.
 
 ## SIP Signaling: Ports
 


### PR DESCRIPTION
Removed reference to sip-all.pstnhub.microsoft.com in advance of future changes in DR