### PR TITLE
Removing sentence in what-are-dial-plans.md

### DIFF
--- a/Teams/what-are-dial-plans.md
+++ b/Teams/what-are-dial-plans.md
@@ -55,7 +55,7 @@ The following are the possible effective dial plans:
 See [Create and manage dial plans](create-and-manage-dial-plans.md) to create your tenant dial plans.
 
 > [!NOTE]
-> In the scenario where no dial plan normalization rules apply to a dialed number, the dialed string is still normalized to prepend "+CC" where CC is the country code of the dialing user's usage location. This applies to Calling Plans, Direct Routing and PSTN Conference dial-out scenarios. Additionally, if a tenant dial plan normalization rule results in a number that does not start with "+", the calling service will attempt to normalize the number received from the Teams client based on the tenant dial plan, and if not matched, on the region dial plan. To avoid double normalization, it's recommended that Direct Routing customers normalize numbers to include a + and then remove the + using Trunk Translation rules. 
+> In the scenario where no dial plan normalization rules apply to a dialed number, the dialed string is still normalized to prepend "+CC" where CC is the country code of the dialing user's usage location. This applies to Calling Plans, Direct Routing and PSTN Conference dial-out scenarios.
 
 ## Planning for tenant dial plans
 


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/8279.

@carolynblanding, could you kindly help me to confirm this sentence? I have tested it and I'm suggesting the removal but I think you can provide more information as you added it 6 months ago.

My test:
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/33589238/147740960-aa7de0b5-9462-4ed9-bd08-440ade0d07ba.png">

Maybe we cannot check the double normalization with Test-CsEffectiveTenantDialPlan.

Thanks!