### PR TITLE
Adding the media file log location for MAC

### DIFF
--- a/Teams/log-files.md
+++ b/Teams/log-files.md
@@ -121,7 +121,7 @@ To collect logs for Windows:
   - `%userprofile%\Downloads\MSTeams Diagnostics Log\meeting\media-stack\\\*\.blog`
   - `%userprofile%\Downloads\MSTeams Diagnostics Log\meeting\skylib\\\*\.blog` 
 
-To collect logs for MAC:  
+To collect logs for Mac:
 - The files will be available in the following locations:
   - `~/Library/Application Support/Microsoft/Teams/media-stack\\\*\.blog`
   - `~/Library/Application Support/Microsoft/Teams/skylib\\\*\.blog`

--- a/Teams/log-files.md
+++ b/Teams/log-files.md
@@ -121,6 +121,11 @@ To collect logs for Windows:
   - `%userprofile%\Downloads\MSTeams Diagnostics Log\meeting\media-stack\\\*\.blog`
   - `%userprofile%\Downloads\MSTeams Diagnostics Log\meeting\skylib\\\*\.blog` 
 
+To collect logs for MAC:  
+- The files will be available in the following locations:
+  - `~/Library/Application Support/Microsoft/Teams/media-stack\\\*\.blog`
+  - `~/Library/Application Support/Microsoft/Teams/skylib\\\*\.blog`
+
 Here's a list of the log files that are generated and the information they contain.
 
 <br/>


### PR DESCRIPTION
Teams Media logs file location was missing for MAC device, updated the same