### PR TITLE
Update private-channels-life-cycle-management.md

### DIFF
--- a/Teams/private-channels-life-cycle-management.md
+++ b/Teams/private-channels-life-cycle-management.md
@@ -43,13 +43,20 @@ As an admin, you can use the Graph API to create a private channel on behalf of 
 
 ```Graph API
 POST /teams/{id}/channels
-{ "membershipType": "Private",
-  "displayName": "<Channel_Name>",
-  "members":[{    
-           "@odata.type":"#microsoft.graph.aadUserConversationMember",
-           "user@odata.bind":"https://graph.microsoft.com/users('<user_id>')",
-           "roles":["owner"]
-            }]
+{
+    "membershipType": "Private",
+    "displayName": "<Channel_Name>",
+    "members": [
+        {
+            "@odata.type": "#microsoft.graph.aadUserConversationMember",
+            "user@odata.bind": "https://graph.microsoft.com/v1.0/users('<user_id>')",
+            "roles": [
+                "owner"
+            ]
+        }
+    ]
+}
+            
 ```
 
 ## Get a list of all private channel messages


### PR DESCRIPTION
fixes broken example to create a private Channel:
- the object wasn't closed by a `}`, 
- also adds the missing  `v1.0/` in the `user@odata.bind` property

(Keep up the good work, love Graph 🦒)