### PR TITLE
Adhere to current Debian recommendations for apt keys

### DIFF
--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -134,9 +134,9 @@ You can launch Teams via Activities or via Terminal by typing `teams`.
 Install manually on Debian and Ubuntu distributions:
 
 ```bash
-curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-archive-keyring.gpg
 
-sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/ms-teams stable main" > /etc/apt/sources.list.d/teams.list'
+sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/ms-teams stable main" > /etc/apt/sources.list.d/teams.list'
 
 sudo apt update
 sudo apt install teams


### PR DESCRIPTION
The current recommendation for secure configuration apt keys is to use per-repo `signed-by=` option with the key stored in `/usr/share/keyrings`. This ensures that this key won't cause the system to accept signatures on *all* other repositories configured on the system that don't have a signed-by option (including the official Debian repositories).

From Debian's wiki:
> The key MUST NOT be placed in `/etc/apt/trusted.gpg.d` or loaded by `apt-key add`
https://wiki.debian.org/DebianRepository/UseThirdParty

This is just a documentation part, this would still need to be fixed in the package as `ms-teams` package unconditionally adds the key under `/etc/apt/trusted.gpg.d/microsoft.gpg` in `postinstall` script if it doesn't already exist.