### PR TITLE
Add Digicert root certificate to SBC

### DIFF
--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -179,7 +179,7 @@ Learn more:
 - DigiCert High Assurance EV Root CA
 
 > [!NOTE]
-> If Mutual TLS (MTLS) support is enabled for the Teams connection on the SBC, then you must install the Baltimore CyberTrust Root Certificate in the SBC Trusted Root Store of the Teams TLS context. (This is because the Microsoft service certificates use the Baltimore root certificate.) To download the Baltimore root certificate, see [Office 365 Encryption chains](/microsoft-365/compliance/encryption-office-365-certificate-chains).
+> If Mutual TLS (MTLS) support is enabled for the Teams connection on the SBC, then you must install the Baltimore CyberTrust Root and the DigiCert Global Root G2 certificates in the SBC Trusted Root Store of the Teams TLS context. (This is because the Microsoft service certificates use one of these two root certificates.) To download these root certificates, see [Office 365 Encryption chains](/microsoft-365/compliance/encryption-office-365-certificate-chains). For more details, see [Office TLS Certificate Changes](/microsoft-365/compliance/encryption-office-365-tls-certificates-changes).
 
 ## SIP Signaling: FQDNs 
 


### PR DESCRIPTION
Update instructions for SBC owners using MTLS to ensure they trust the DigiCert Global Root G2 certificate.