### PR TITLE
E2EE now in GA

### DIFF
--- a/Teams/teams-end-to-end-encryption.md
+++ b/Teams/teams-end-to-end-encryption.md
@@ -3,7 +3,7 @@ title: End-to-end encryption for Microsoft Teams
 author: kccross
 ms.author: krowley
 manager: laurawi
-ms.date: 10/23/2021
+ms.date: 03/08/2022
 ms.topic: conceptual
 ms.service: msteams
 audience: admin
@@ -21,14 +21,14 @@ appliesto:
   - Microsoft Teams
 ---
 
-# Use end-to-end encryption for one-to-one Microsoft Teams calls (Public preview)
+# Use end-to-end encryption for one-to-one Microsoft Teams calls
 
 > [!IMPORTANT]
 > The Teams service model, and its encryption support, is subject to change in order to improve customer experiences. For example, the service regularly deprecates cipher suites that are no longer considered secure. Any such changes would be made with the goal of keeping Teams secure and Trustworthy by Design. In addition, all customer content in Microsoft data centers is encrypted. For information about encryption layers in Microsoft 365, see [Encryption in Microsoft 365](/microsoft-365/compliance/encryption).
 
 End-to-end encryption, or E2EE, happens when content is encrypted before it's sent and decrypted only by the intended recipient. With end-to-end encryption, only the two endpoint systems are involved in encrypting and decrypting the call data. No other party, including Microsoft, has access to the decrypted conversation.
 
-With this public preview release, we're rolling out E2EE for unscheduled one-to-one calls. Only the real-time media flow, that is, video and voice data, for one-to-one Teams calls are end-to-end encrypted. Both parties must turn on this setting to enable end-to-end encryption. [Encryption in Microsoft 365](/microsoft-365/compliance/encryption) protects chat, file sharing, presence, and other content in the call.
+With E2EE for unscheduled one-to-one calls, only the real-time media flow, that is, video and voice data, for one-to-one Teams calls are end-to-end encrypted. Both parties must turn on this setting to enable end-to-end encryption. [Encryption in Microsoft 365](/microsoft-365/compliance/encryption) protects chat, file sharing, presence, and other content in the call.
 
 If you don't enable end-to-end encryption, Teams still secures a call or meeting using encryption based on industry standards. Data exchanged during calls is always secure while in transit and at rest. For more information, see [Media encryption for Teams](teams-security-guide.md#media-encryption).
 


### PR DESCRIPTION
Changed to reflect that E2EE is no longer in preview. Instead, E2EE is now GA.