### PR TITLE
Update site template id in private-channels.md

### DIFF
--- a/Teams/private-channels.md
+++ b/Teams/private-channels.md
@@ -81,7 +81,7 @@ The following table outlines what actions owners, members, and guests can do in 
 
 ## Private channel SharePoint sites
 
-Each private channel has its own SharePoint site. The separate site is to ensure access to private channel files is restricted to only members of the private channel. These sites are created with a document library by default, and can be easily enhanced to a full-featured site through the [site management interface](https://support.office.com/article/A2F2A5C2-093D-4897-8B7F-37F86D83DF04). Each site is created in the same geographic region as the site for the parent team. These lightweight sites have a custom template ID, "TEAMCHANNEL#0", for easier management through PowerShell and Graph API. 
+Each private channel has its own SharePoint site. The separate site is to ensure access to private channel files is restricted to only members of the private channel. These sites are created with a document library by default, and can be easily enhanced to a full-featured site through the [site management interface](https://support.office.com/article/A2F2A5C2-093D-4897-8B7F-37F86D83DF04). Each site is created in the same geographic region as the site for the parent team. These lightweight sites have a custom template ID, "TEAMCHANNEL#0" or "TEAMCHANNEL#1", for easier management through PowerShell and Graph API. 
 
 > [!NOTE]
 > Only people with owner or member permissions in the channel will have access to content in the shared channel site. People in the parent team and admins won't have access unless they are also channel members.


### PR DESCRIPTION
SharePoint sites for private channels created after June 28, 2021 use "TEAMCHANNEL#1" for site template id. The information is published in other article, and this document should be updated.
https://docs.microsoft.com/en-us/microsoftteams/ediscovery-investigation#include-private-channel-files-in-an-ediscovery-search