### PR TITLE
Clarifying what "0.1" means in package loss

### DIFF
--- a/Teams/stream-classification-in-call-quality-dashboard.md
+++ b/Teams/stream-classification-in-call-quality-dashboard.md
@@ -37,7 +37,7 @@ If one or more of the following conditions are met, an audio stream is marked as
 |Metric|Scenario|Condition|Explanation|
 |:-----|:-----|:-----|:-----|
 |Round Trip|ALL|> 500|Average round-trip network propagation time, computed in milliseconds. Details available in [RFC3550](https://tools.ietf.org/html/rfc3550).|
-|Packet Loss Rate|ALL|> 0.1|Average packet loss rate for stream.|
+|Packet Loss Rate|ALL|> 0.1|Average packet loss rate for stream. (0.1 indicates 10% packet loss.)|
 |Jitter|ALL|> 30|Average jitter for stream in milliseconds.|
 ||||
 


### PR DESCRIPTION
As on other page of CQD state:
"Average packet loss rate for stream. Values grouped by range. 0.1 indicates 10% packet loss."
I believe it is the same on this table.

Source: [Dimensions and measurements available in Call Quality Dashboard (CQD)](https://docs.microsoft.com/en-us/microsoftteams/dimensions-and-measures-available-in-call-quality-dashboard)