### PR TITLE
Update get-clients.md

### DIFF
--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -34,8 +34,8 @@ For details about each client's capabilities on different platforms, see [Teams 
 
 The Teams desktop client is available as a standalone application and as part of [Microsoft 365 Apps for enterprise](/deployoffice/teams-install) for the following operating systems:
 
-- 32-bit and 64-bit versions of Windows (8.1 or later)
-- ARM64 for Windows 10 on ARM (excluding Windows 10 LTSC)
+- 32-bit and 64-bit versions of Windows (8.1 or later, excluding Windows 10 LTSC) 
+- ARM64 for Windows 10 on ARM 
 - Windows Server (2012 R2 or later)
 - macOS
 - Linux (in `.deb` and `.rpm` formats)

--- a/Teams/get-clients.md
+++ b/Teams/get-clients.md
@@ -35,7 +35,7 @@ For details about each client's capabilities on different platforms, see [Teams 
 The Teams desktop client is available as a standalone application and as part of [Microsoft 365 Apps for enterprise](/deployoffice/teams-install) for the following operating systems:
 
 - 32-bit and 64-bit versions of Windows (8.1 or later)
-- ARM64 for Windows 10 on ARM
+- ARM64 for Windows 10 on ARM (excluding Windows 10 LTSC)
 - Windows Server (2012 R2 or later)
 - macOS
 - Linux (in `.deb` and `.rpm` formats)


### PR DESCRIPTION
In the following article we call out that Windows 10 LTSC does not Teams web but in this article we dont mention it which causes confusion to customers on support for Teams web on Windows 10 LTSC.
https://docs.microsoft.com/en-us/microsoftteams/hardware-requirements-for-the-teams-app