### PR TITLE
Update assign-policies-users-and-groups.md

### DIFF
--- a/Teams/assign-policies-users-and-groups.md
+++ b/Teams/assign-policies-users-and-groups.md
@@ -108,6 +108,9 @@ A user's effective policy is updated according to these rules:
 
 #### Group assignment ranking
 
+[!NOTE]
+A given policy type can be assigned to at most 64 groups, across policy instances for that type.
+
 When you assign a policy to a group, you specify a ranking for the group assignment. This is used to determine which policy a user should inherit as their effective policy if the user is a member of two or more groups and each group is assigned a policy of the same type.
 
 The group assignment ranking is relative to other group assignments of the same type. For example, if you're assigning a calling policy to two groups, set the ranking of one assignment to 1 and the other to 2, with 1 being the highest ranking. The group assignment ranking indicates which group membership is more important or more relevant than other group memberships with regard to inheritance.

--- a/Teams/assign-policies-users-and-groups.md
+++ b/Teams/assign-policies-users-and-groups.md
@@ -108,8 +108,8 @@ A user's effective policy is updated according to these rules:
 
 #### Group assignment ranking
 
-[!NOTE]
-A given policy type can be assigned to at most 64 groups, across policy instances for that type.
+> [!NOTE]
+> A given policy type can be assigned to a maximum of 64 groups across policy instances for that type.
 
 When you assign a policy to a group, you specify a ranking for the group assignment. This is used to determine which policy a user should inherit as their effective policy if the user is a member of two or more groups and each group is assigned a policy of the same type.
 


### PR DESCRIPTION
Not sure what you think would be more appropriate. 
Adding the remark as I did as a note under "Group Assignment Ranking" ... or under the next section: "In the Teams admin center" in the existing note.

(but since it's regarding the number of policies, it makes sense to be in the same place where numbers/rankings of policies are managed)