### PR TITLE
Update operator-connect-configure.md

### DIFF
--- a/Teams/operator-connect-configure.md
+++ b/Teams/operator-connect-configure.md
@@ -102,10 +102,10 @@ To move numbers from Direct Routing to Operator Connect, the existing Direct Rou
 How you remove your existing Direct Routing numbers depends whether the number is assigned on-premises or online. To check, run the following command:
     
 ```PowerShell
-Get-CsOnlineUser -Identity <user> | fl RegistrarPool,OnPreLineURIManuallySet, OnPremLineURI, LineURI 
+Get-CsOnlineUser -Identity <user> | fl RegistrarPool,OnPremLineURI,LineURI 
 ```
 
-If `OnPremLineUriManuallySet` is set to `False` and `LineUri` is populated with an E.164 phone number, the phone number was assigned on-premises and synchronized to Office 365.
+If `LineUri` is populated with an E.164 phone number, the phone number was assigned on-premises and synchronized to Office 365.
     
 **To remove Direct Routing numbers assigned on-premises,** run the following command:
     
@@ -116,15 +116,14 @@ Set-CsUser -Identity <user> -LineURI $null
 The amount of time it takes for the removal to take effect depends on your configuration. To check if the on-premises number was removed and the changes have been synced, run the following PowerShell command: 
     
 ```PowerShell
-Get-CsOnlineUser -Identity <user> | fl RegistrarPool,OnPreLineURIManuallySet, OnPremLineURI, LineURI 
+Get-CsOnlineUser -Identity <user> | fl RegistrarPool,OnPremLineURI,LineURI
 ```
        
 After the changes have synced to Office 365 online directory, the expected output is: 
        
  ```console
 RegistrarPool                        : pool.infra.lync.com
- OnPremLineURIManuallySet             : True
- OnPremLineURI                        : 
+OnPremLineURI                        : 
 LineURI                              : 
 ```
 


### PR DESCRIPTION
According to below link, it says that OnPremLineUriManuallySet is now deprecated as OnPremLineURI is representative of the On-Prem assignment, then OnPremLineUriManuallySet may be deleted accordingly. 

https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlineuser?view=skype-ps