### PR TITLE
Removed references to Power BI

### DIFF
--- a/Teams/Office-365-groups.md
+++ b/Teams/Office-365-groups.md
@@ -21,7 +21,7 @@ description: Learn about how Microsoft 365 groups and group memberships work wit
 
 # Microsoft 365 Groups and Microsoft Teams
 
-Microsoft 365 Groups is the cross-application membership service in Microsoft 365. At a basic level, a Microsoft 365 Group is an object in Azure Active Directory with a list of members and a coupling to related workloads including a SharePoint team site, shared Exchange mailbox, Planner and Power BI workspace. You can add or remove people to the group just as you would any other group-based security object in Active Directory.
+Microsoft 365 Groups is the cross-application membership service in Microsoft 365. At a basic level, a Microsoft 365 Group is an object in Azure Active Directory with a list of members and a coupling to related workloads including a SharePoint team site, shared Exchange mailbox, Planner, and OneNote notebook. You can add or remove people to the group just as you would any other group-based security object in Active Directory.
 
 ![Diagram showing Microsoft 365 Groups and related services.](/microsoft-365/media/microsoft-365-groups-hub-spoke.png?view=o365-worldwide)
 
@@ -29,7 +29,7 @@ By default, users in Microsoft 365 can create and manage groups. For more inform
 
 ## How Microsoft 365 Groups work with Teams
 
-When you create a team, a Microsoft 365 group is created to manage team membership. The group's related services, such as a SharePoint site, Power BI workspace, etc. are created at the same time.
+When you create a team, a Microsoft 365 group is created to manage team membership. The group's related services, such as a SharePoint site, mailbox, etc. are created at the same time.
 
 People who create teams can choose to use an existing Microsoft 365 group if they are an owner of that group. Each channel in the team has a separate folder in the document library. Creating folders directly in the document library does not create channels in the team.
 


### PR DESCRIPTION
Power BI workspaces are no longer provisioned with M365 Groups.
I have removed the references to Power BI, and replaced them with references to the mailbox or OneNote notebook.