### PR TITLE
Fixed typos

### DIFF
--- a/Teams/plan-auto-attendant-call-queue.md
+++ b/Teams/plan-auto-attendant-call-queue.md
@@ -123,7 +123,7 @@ You can use a combination of these options for each queue if needed. Groups that
 
 We recommend choosing a strategy for adding call agents to queues before you start your configuration.
 
-If you have an existing auto attendant and call queue infrastructure and you're migrating to Teams, you'll need a plan to transfer your existing phone numbers to the new auto attendants and call queues. You might need to create a [port order](phone-number-calling-plans/port-order-overview.md) to move your numbers from another providers. We recommend that you temporarily acquire one or more new phone numbers and test your auto attendant and call queue flows before switching them over the numbers you currently have in service.
+If you have an existing auto attendant and call queue infrastructure and you're migrating to Teams, you'll need a plan to transfer your existing phone numbers to the new auto attendants and call queues. You might need to create a [port order](phone-number-calling-plans/port-order-overview.md) to move your numbers from another providers. We recommend that you temporarily acquire one or more new phone numbers and test your auto attendant and call queue flows before switching them over to the numbers you currently have in service.
 
 *Conference mode* is an option in call queues that significantly reduces the amount of time it takes to connect Teams VOIP calls and PSTN calls to an agent. For conference mode to work, agents in the call queue must use one of the following clients:
 
@@ -193,7 +193,7 @@ Here are some call routing best practices:
 - If you receive numerous calls requesting basic information about your company, such as business hours, location, or web site address, consider creating an auto attendant to answer these questions with recorded messages.
 - Keep the list of menu items to five or fewer. Callers can have trouble remembering more than five options. Use nested auto attendants if more options are needed to properly route a call.
 - Describe the service first, followed by the option to press (eg: For Sales press 1) rather than the other way around (eg. Press 1 for Sales).
-- User terminology your callers will understand rather than what you may use internally.
+- Use terminology your callers will understand rather than what you may use internally.
 - Avoid frequent updates to call routing. If you change your menu options for an auto attendant in the future, call that out in the voice prompts for the first 30 days.
 
 ## Getting started


### PR DESCRIPTION
Changed "User terminology" to "Use terminology" and "switching them over the numbers" to "switching them over to the numbers".