### PR TITLE
Update set-up-communications-credits-for-your-organization.md

### DIFF
--- a/Teams/set-up-communications-credits-for-your-organization.md
+++ b/Teams/set-up-communications-credits-for-your-organization.md
@@ -80,7 +80,7 @@ For more information, see [Microsoft Teams add-on licensing](./teams-add-on-lice
     
 6. Select **Place order**.
     >[!IMPORTANT]
-    >If you are a volume licensing customer, you may choose your enterprise agreement number for payment. If you have multiple enterprise agreement numbers, you will be able to select which enterprise agreement you would like to use for payment. You will also be given an opportunity to specify a purchase order number to associate with the enterprise agreement number (if applicable).
+    >If you are a volume licensing customer, you may wish to use your enterprise agreement for payment. If you want to do this, open a Premier Support case to ahve this enabled. If you have multiple enterprise agreement numbers, you will be able to select which enterprise agreement you would like to use for payment. You will also be given an opportunity to specify a purchase order number to associate with the enterprise agreement number (if applicable) once Support enables this.
     
 Each organization will have a different usage of Calling Plan volume and rates to consider. You will need to get this type of usage data from your current service provider. Organizations already using Skype for Business Online or Microsoft Teams as their service provider can get usage data by reviewing it in the **Microsoft Teams admin center** > **Analytics & reports** > **Usage reports** > **PSTN and SMS (preview) usage** report.
   


### PR DESCRIPTION
Customers cannot choose to use their EA unless they first open a support ticket to have that option enabled in their tenant. Updated the wording to indicate that they must first engage Support to enable this as an option.