### PR TITLE
Remove shortcut info

### DIFF
--- a/Teams/msi-deployment.md
+++ b/Teams/msi-deployment.md
@@ -114,7 +114,7 @@ For the 64-bit version:
 msiexec /i Teams_windows_x64.msi OPTIONS="noAutoStart=true" ALLUSERS=1
 ```
 
-When a user logs in to Windows, Teams is installed with the MSI and a shortcut to start Teams is added to the user's desktop. Teams won't start until the user manually starts Teams. After the user manually starts Teams, Teams automatically starts whenever the user logs in.
+When a user logs in to Windows, Teams is installed with the MSI. Teams won't start until the user manually starts Teams. After the user manually starts Teams, Teams automatically starts whenever the user logs in.
 
 Note that these examples also use the **ALLUSERS=1** parameter. When you set this parameter, Teams Machine-Wide Installer appears in Programs and Features in Control Panel and in Apps & features in Windows Settings for all users of the computer. All users can then uninstall Teams if they have admin credentials on the computer.
 


### PR DESCRIPTION
closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/8855

confirmed with product team that this is now the default behavior and also reproduced.