### PR TITLE
Updating Teams admin center instructions

### DIFF
--- a/Teams/teams-skype-interop.md
+++ b/Teams/teams-skype-interop.md
@@ -81,7 +81,7 @@ If you upgraded from Skype for Business to Teams, the external communications se
 
 ### In the Microsoft Teams admin center
 
-In the Microsoft Teams admin center, go to **Org-wide settings** > **External access**, and then turn on **Users can communicate with Skype users**. For step-by-step guidance on how to configure this and other external access settings, see [Manage external access in Teams](./manage-external-access.md#allow-or-block-domains).
+In the Microsoft Teams admin center, go to **Users** > **External access**, and then turn on **Users can communicate with Skype users**. For step-by-step guidance on how to configure this and other external access settings, see [Manage external access in Teams](./manage-external-access.md#allow-or-block-domains).
 
 ### Using PowerShell
 


### PR DESCRIPTION
"Org-wide settings" is no longer a top-level menu option in the Teams admin center. External access is now located under Users. This PR updates the admin center instructions to reflect this.