### PR TITLE
Remove sections which does not related to subject

### DIFF
--- a/Teams/proxy-servers-for-skype-for-business-online.md
+++ b/Teams/proxy-servers-for-skype-for-business-online.md
@@ -38,19 +38,6 @@ And having a proxy can cause issues. Performance-related problems can be introdu
 
 Some organizations have no option to bypass a proxy for Teams or Skype for Business traffic. If that's the case for you, the problems mentioned above need to be kept in mind.
   
-Microsoft also strongly recommends:
-  
-- Using external DNS resolution
-    
-- Using direct UDP based routing
-    
-- Allowing UDP traffic
-    
-- Following the other recommendations in our networking guidelines:
-  [Prepare your organization's network for Teams](prepare-network.md)
-  
-    
-Following this guidance should minimize potential problems.
   
 ## Related topics
 


### PR DESCRIPTION

When customers are forced to use proxies, then that is something which need to be accepted. That is very much used way to protecting corporate networks. I have removed those lines, as in my mind there are no purposes to guide customers who are forced to use proxy, to say:

```
Microsoft also strongly recommends:

- Using external DNS resolution
- Using direct UDP based routing
- Allowing UDP traffic
```

**DNS** is not required in a case of proxy. Teams clients behind proxy does not need to resolve external names. Proxy does that work for the clients.
The **UDP** was twice on the list, but the bigger problem on the UDP is, when using proxy services the UDP is not an option. So in my mind it is misleading customers when proposals like this are given to them.

The last bullet is listed already on the related section, so it is not required on here.
And last line does not make really sense, as there are no guidelines to help customers with the proxy. This page just say what are the expectations when proxy is used for Teams.