### PR TITLE
Inconsistency in the Engagement report doc

### DIFF
--- a/Teams/meeting-policies-in-teams-general.md
+++ b/Teams/meeting-policies-in-teams-general.md
@@ -120,7 +120,7 @@ Keep in mind that after you set the default value, meeting organizers can still 
 
 This is a per-user policy. This setting controls whether meeting organizers can download the [meeting attendance report](teams-analytics-and-reports/meeting-attendance-report.md).
 
-This policy is on by default and allows your organizers to see who registered and attended the meetings and webinars they set up. To turn it off in the Teams admin center, go to **Meetings** > **Meeting policies**, and set the **Engagement report** setting to **Off**.
+This policy is off by default. If you turn this on, your organizers can see who registered and attended the meetings and webinars they set up. To turn it on in the Teams admin center, go to **Meetings** > **Meeting policies**, and set the **Engagement report** setting to **Turn on**.
 
 You can also edit an existing Teams meeting policy by using the [Set-CsTeamsMeetingPolicy](/powershell/module/skype/set-csteamsmeetingpolicy) cmdlet. Or, create a new Teams meeting policy by using the [New-CsTeamsMeetingPolicy](/powershell/module/skype/new-csteamsmeetingpolicy) cmdlet and assign it to users.
 


### PR DESCRIPTION
The Engagement report default value is Off. This is mentioned in the notes of [View and download meeting attendance reports in Teams](https://support.microsoft.com/en-us/office/view-and-download-meeting-attendance-reports-in-teams-ae7cf170-530c-47d3-84c1-3aedac74d310) and in [Microsoft Teams meeting attendance report](https://docs.microsoft.com/en-us/microsoftteams/teams-analytics-and-reports/meeting-attendance-report). The option is turned off when a new Teams meeting policy is created from Teams admin portal, but Enabled when a new Teams meeting policy is created in PowerShell.

![image](https://user-images.githubusercontent.com/12202898/177519131-1cb51aad-09eb-4925-abc5-3902e88aabd4.png)

![image](https://user-images.githubusercontent.com/12202898/177519177-1252c6bb-05e2-4426-a10c-5b23cf9fb363.png)