### PR TITLE
Increase Members per Tag Limit

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -223,7 +223,7 @@ A class team can support more than 300 members. However, if you plan to use eith
 |---------|---------|
 |Number of tags per team    | 100        |
 |Number of suggested default tags per team    | 25        |
-|Number of team members assign to a tag    |100         |
+|Number of team members assign to a tag    |200         |
 |Number of tags assigned to a user per team    |25         |
 
 ## Contacts


### PR DESCRIPTION
Tag member limit was updated, and the following doc was already updated.
https://docs.microsoft.com/en-us/microsoftteams/manage-tags
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/pull/8867/commits/d8c6a8808c9971ffdf382ba3693dfea9d3940333
----------
A team can have up to 100 tags, up to 200 team members can be assigned to a tag, and up to 25 tags in the same team can be assigned to a single user.
----------

Updating this doc as well.