### PR TITLE
Remove install on meeting from teams-app-setup-policies.md

### DIFF
--- a/Teams/teams-app-setup-policies.md
+++ b/Teams/teams-app-setup-policies.md
@@ -83,7 +83,6 @@ Using an app setup policy, an admin can achieve the following tasks:
 
 * Install apps for end-users in their personal Teams environment, by default.
 * Install apps for end-users as [messaging extensions](/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions).
-* Install apps in meetings for meeting organizers.
 
 The end-users can install apps on their own if the [app permission policy](teams-app-permission-policies.md) allows it.
 


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/8843.

Agree, that we cannot add apps to meetings with Setup Policies. They are just installed in the personal Teams environment.