### PR TITLE
Policy setting is ON by default

### DIFF
--- a/Teams/teams-analytics-and-reports/meeting-attendance-report.md
+++ b/Teams/teams-analytics-and-reports/meeting-attendance-report.md
@@ -26,7 +26,7 @@ Meeting organizers can view and download a meeting attendance report. Find this 
 
 For education tenants, this report is useful to track student attendance in online classes. For example, the teacher can download the attendance report at the start of class as a simple way to do a "roll call." To learn more, read [Download attendance reports in Teams](https://support.office.com/article/download-attendance-reports-in-teams-ae7cf170-530c-47d3-84c1-3aedac74d310).
 
-As an admin, you control whether meeting organizers can download meeting attendance reports by setting a Teams meeting policy. By default, the ability to download the report is turned off. For steps on how to turn on this feature, see [Meeting policy settings - Allow engagement report](../meeting-policies-in-teams-general.md#engagement-report).
+As an admin, you control whether meeting organizers can download meeting attendance reports by setting a Teams meeting policy. By default, the ability to download the report is turned on. For steps on how to turn off this feature, see [Meeting policy settings - Allow engagement report](../meeting-policies-in-teams-general.md#engagement-report).
 
 If meeting organizers need access to more meeting attendance data than they get from the report available within the meeting, you can assign the *Report reader* role so they can access the Teams admin reports themselves. To learn about this, read [Who can access the Teams activity reports](../teams-activity-reports.md#who-can-access-the-teams-activity-reports). 
 


### PR DESCRIPTION
Per the doc page linked below, and verified in my own tenant's meeting policies, the engagement report settings is turned ON by default, not off. 
https://docs.microsoft.com/en-US/microsoftteams/meeting-policies-in-teams-general?WT.mc_id=TeamsAdminCenterCSH#engagement-report