### PR TITLE
Update shared-channels.md

### DIFF
--- a/Teams/shared-channels.md
+++ b/Teams/shared-channels.md
@@ -206,7 +206,6 @@ The following apps are supported for use in shared channels.
 - Smartsheet
 - SurveyMonkey
 - Tasks in a Box
-- Teams
 - Teams Manager
 - TeamViewer
 - Teamwork


### PR DESCRIPTION
Teams probably doesn't need to be listed as a supported 1p/3p app for shared channels? Could this be a typo/truncation of a different app? 