### PR TITLE
Remove not included features in eDiscovery-investigation.md

### DIFF
--- a/Teams/eDiscovery-investigation.md
+++ b/Teams/eDiscovery-investigation.md
@@ -31,25 +31,25 @@ eDiscovery of messages and files in [private channels](private-channels.md) work
 
 Not all Teams content is eDiscoverable. The following table shows the content types that you can search for using Microsoft eDiscovery tools:
 
-|Content type|eDiscoverable|Notes|
-|---|---|---|
-|Audio recordings|Yes||
-|Card content|Yes|See [Search for card content](#search-for-card-content) for more information.|
-|Chat links|Yes||
-|Chat messages|Yes|This includes content in standard Teams channels, 1:1 chats, 1:N group chats, and chats with guest user participants.|
-|Code snippets|No||
-|Edited messages|Yes|If the user is on hold, previous versions of edited messages are also preserved.|
-|Emojis, GIFs, and stickers|Yes||
+|Content type|Notes|
+|---|---|
+|Audio recordings||
+|Card content|See [Search for card content](#search-for-card-content) for more information.|
+|Chat links||
+|Chat messages|This includes content in standard Teams channels, 1:1 chats, 1:N group chats, and chats with guest user participants.|
+|Code snippets||
+|Edited messages|If the user is on hold, previous versions of edited messages are also preserved.|
+|Emojis, GIFs, and stickers||
 |Feed notifications|No||
-|Inline images|Yes||
-|Loop components|Yes|Content in a loop component is saved in a .fluid file that's stored in the OneDrive for Business account of the user who sends the loop component. That means you have to include OneDrive as a data source when searching for content in loop components.|
-|Meeting IM conversations|Yes||
-|Meeting metadata<sup>1</sup>|Yes||
-|Name of channel|Yes||
-|Quotes|Yes|Quoted content is searchable. However, search results don't indicate that the content was quoted.|
-|Reactions (such as likes, hearts, and other reactions)|Yes|Reactions are supported for all commercial customers after June 1, 2022. Reactions before this date are not available for eDiscovery. Government cloud support is planned. There is no legal hold support for reactions.|
-|Subject|Yes||
-|Tables|Yes||
+|Inline images||
+|Loop components|Content in a loop component is saved in a .fluid file that's stored in the OneDrive for Business account of the user who sends the loop component. That means you have to include OneDrive as a data source when searching for content in loop components.|
+|Meeting IM conversations||
+|Meeting metadata<sup>1</sup>||
+|Name of channel||
+|Quotes|Quoted content is searchable. However, search results don't indicate that the content was quoted.|
+|Reactions (such as likes, hearts, and other reactions)|Reactions are supported for all commercial customers after June 1, 2022. Reactions before this date are not available for eDiscovery. Government cloud support is planned. There is no legal hold support for reactions.|
+|Subject||
+|Tables||
 
 <sup>1</sup> Meeting (and call) metadata includes the following:
 

--- a/Teams/eDiscovery-investigation.md
+++ b/Teams/eDiscovery-investigation.md
@@ -40,7 +40,6 @@ Not all Teams content is eDiscoverable. The following table shows the content ty
 |Code snippets||
 |Edited messages|If the user is on hold, previous versions of edited messages are also preserved.|
 |Emojis, GIFs, and stickers||
-|Feed notifications|No||
 |Inline images||
 |Loop components|Content in a loop component is saved in a .fluid file that's stored in the OneDrive for Business account of the user who sends the loop component. That means you have to include OneDrive as a data source when searching for content in loop components.|
 |Meeting IM conversations||


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/9018.

@v-tophillips, do you agree? I think we should add only the eDiscoverable content. We won't be able to include ALL the non-eDiscoverable content in the table.