### PR TITLE
SBA requires ICMP otherwise it will not work.

### DIFF
--- a/Teams/direct-routing-survivable-branch-appliance.md
+++ b/Teams/direct-routing-survivable-branch-appliance.md
@@ -45,7 +45,7 @@ To get the latest Session Border Controller firmware with the embedded Survivabl
 - UDP Port 123 is used by Microsoft SBA Server to communicate with NTP server and should be allowed on the firewall.
 - Port 443 is used by Microsoft SBA Server to communicate with Microsoft 365 and should be allowed on the firewall.
 - Azure IP Ranges and Service Tags for the Public Cloud should be defined according to the guidelines described at: https://www.microsoft.com/download/details.aspx?id=56519
--  ICMP to www.microsoft.com is used by Microsoft SBA Server to determine the current status of the Internet Connection and should allowed on the firewall. 
+-  ICMP to www.microsoft.com is used by Microsoft SBA Server to determine the current status of the Internet connection and should be allowed on the firewall. 
 
 ## Supported Teams clients
 

--- a/Teams/direct-routing-survivable-branch-appliance.md
+++ b/Teams/direct-routing-survivable-branch-appliance.md
@@ -45,6 +45,7 @@ To get the latest Session Border Controller firmware with the embedded Survivabl
 - UDP Port 123 is used by Microsoft SBA Server to communicate with NTP server and should be allowed on the firewall.
 - Port 443 is used by Microsoft SBA Server to communicate with Microsoft 365 and should be allowed on the firewall.
 - Azure IP Ranges and Service Tags for the Public Cloud should be defined according to the guidelines described at: https://www.microsoft.com/download/details.aspx?id=56519
+-  ICMP to www.microsoft.com is used by Microsoft SBA Server to determine the current status of the Internet Connection and should allowed on the firewall. 
 
 ## Supported Teams clients
 


### PR DESCRIPTION
ICMP to www.microsoft.com is required as part of the firewall requirements.
If ICMP is denied on the firewall then the SBA will not function and there is a log  every 30 seconds in the sba.log  "No Internet Connectivity. Waiting 30 seconds."  if you then allow ICMP the SBA works.
If you start and stop the Teams SBA service, then the ICMP ping to www.microsoft.com also starts/stops
Without ICMP the SBA will not function!