### PR TITLE
Update to the licensing section

### DIFF
--- a/Teams/sip-gateway-plan.md
+++ b/Teams/sip-gateway-plan.md
@@ -56,7 +56,7 @@ Teams users must have a phone number with PSTN calling enabled to use SIP Gatewa
 
 If you have a 3PIP or SIP device, you must have:
 
-- A license for Microsoft Teams, Skype for Business Online Plan 2 and Microsoft 365 Phone System (via E5 or a standalone licenses)
+- A license for Microsoft Teams, Skype for Business Online Plan 2, and Microsoft 365 Phone System (via E5 or standalone licenses)
 - PSTN enablement (i.e., a phone number) via a Microsoft Teams Calling Plan, Direct Routing, or Operator Connect
 - A Common Area Phone license for any common area devices
 

--- a/Teams/sip-gateway-plan.md
+++ b/Teams/sip-gateway-plan.md
@@ -56,7 +56,7 @@ Teams users must have a phone number with PSTN calling enabled to use SIP Gatewa
 
 If you have a 3PIP or SIP device, you must have:
 
-- A license for Phone System (via E5 or a standalone license)
+- A license for Microsoft Teams, Skype for Business Online Plan 2 and Microsoft 365 Phone System (via E5 or a standalone licenses)
 - PSTN enablement (i.e., a phone number) via a Microsoft Teams Calling Plan, Direct Routing, or Operator Connect
 - A Common Area Phone license for any common area devices
 


### PR DESCRIPTION
Saying that "A phone system license" is the only license needed is untrue.  You need to have a minimum of these 3 licenses. Microsoft Teams, Skype for Business Online Plan 2 and Microsoft 365 Phone System.   The admin portal wont even let you assign a Phone System license unless you have Teams and Skype for Business Online Plan 2, first.