### PR TITLE
Added Microsoft eCDN 1st party solution

### DIFF
--- a/Teams/teams-live-events/what-are-teams-live-events.md
+++ b/Teams/teams-live-events/what-are-teams-live-events.md
@@ -91,7 +91,7 @@ The live event streaming platform is made up of the following pieces:
 
 ### Enterprise Content Delivery Network (eCDN)
 
-The goal of eCDN is to take the video content from the internet and distribute the content throughout your enterprise without impacting network performance. You can use either [Microsoft's first-party eCDN solution](/ecdn), or alternatively one of the following certified eCDN partners to optimize your network for live events held within your organization:
+The goal of eCDN is to take the video content from the internet and distribute the content throughout your enterprise without impacting network performance. You can use either [Microsoft first-party eCDN solution](/ecdn) or, alternatively, one of the following certified eCDN partners to optimize your network for live events held within your organization:
 
 - [Hive](https://www.hivestreaming.com/partners/integration-partners/microsoft/)
 - [Kollective](https://kollective.com/ecdn-solutions/microsoft-live-events/)

--- a/Teams/teams-live-events/what-are-teams-live-events.md
+++ b/Teams/teams-live-events/what-are-teams-live-events.md
@@ -91,13 +91,12 @@ The live event streaming platform is made up of the following pieces:
 
 ### Enterprise Content Delivery Network (eCDN)
 
-The goal of eCDN is to take the video content from the internet and distribute the content throughout your enterprise without impacting network performance. You can use one of the following certified eCDN partners to optimize your network for live events held within your organization:
+The goal of eCDN is to take the video content from the internet and distribute the content throughout your enterprise without impacting network performance. You can use either [Microsoft's first-party eCDN solution](/ecdn), or alternatively one of the following certified eCDN partners to optimize your network for live events held within your organization:
 
 - [Hive](https://www.hivestreaming.com/partners/integration-partners/microsoft/)
 - [Kollective](https://kollective.com/ecdn-solutions/microsoft-live-events/)
 - [Ramp](https://rampecdn.com)
 - [Riverbed](https://www.riverbed.com/solutions/office-365.html)
-- [Peer5](https://www.peer5.com/)
 
 ### Attendee experience
 

--- a/Teams/teams-live-events/what-are-teams-live-events.md
+++ b/Teams/teams-live-events/what-are-teams-live-events.md
@@ -91,7 +91,7 @@ The live event streaming platform is made up of the following pieces:
 
 ### Enterprise Content Delivery Network (eCDN)
 
-The goal of eCDN is to take the video content from the internet and distribute the content throughout your enterprise without impacting network performance. You can use either [Microsoft first-party eCDN solution](/ecdn) or, alternatively, one of the following certified eCDN partners to optimize your network for live events held within your organization:
+The goal of eCDN is to take the video content from the internet and distribute the content throughout your enterprise without impacting network performance. You can use either the [Microsoft first-party eCDN solution](/ecdn) or, alternatively, one of the following certified eCDN partners to optimize your network for live events held within your organization:
 
 - [Hive](https://www.hivestreaming.com/partners/integration-partners/microsoft/)
 - [Kollective](https://kollective.com/ecdn-solutions/microsoft-live-events/)


### PR DESCRIPTION
I would recommend the Peer5 logo, which is being sunsetted following the company's acquisition by Microsoft in Aug 2021, should be removed from the initial image.