### PR TITLE
Update meeting-policies-participants-and-guests.md

### DIFF
--- a/Teams/meeting-policies-participants-and-guests.md
+++ b/Teams/meeting-policies-participants-and-guests.md
@@ -88,7 +88,7 @@ This setting is a per-user policy and applies during a meeting. This setting con
 
 |Setting value |Behavior  |
 |---------|---------|
-|**Disabled but the user can override**     | Live captions aren't automatically turned on for the user during a meeting. The user sees the **Turn on live captions** option in the overflow (**...**) menu to turn them on. This is the default setting. |
+|**Not enabled but the user can override**     | Live captions aren't automatically turned on for the user during a meeting. The user sees the **Turn on live captions** option in the overflow (**...**) menu to turn them on. This is the default setting. |
 |**Not enabled**     | Live captions are disabled for the user during a meeting. The user doesn't have the option to turn them on.          |
 
 <a name="bkcontentsharing"> </a>


### PR DESCRIPTION
The verbiage in the admin center for Live captions is "Not enabled but user can override" and not "Disabled..."