### PR TITLE
CQD - Update EUII field list

### DIFF
--- a/Teams/CQD-data-and-reports.md
+++ b/Teams/CQD-data-and-reports.md
@@ -69,6 +69,10 @@ For compliance reasons, end-user identifiable information (EUII) data (also know
 - User Verbatim Feedback
 - Object ID (the Active Directory object ID of the endpoint's user)
 - Phone Number
+- Auto Attendant Identity
+- Call Queue Identity
+- Video Teleconferencing (VTC) Device Name
+- Video Teleconferencing (VTC) Device Detail
 
 ### Admin roles with and without EUII access
 


### PR DESCRIPTION
Update document to add these fields that are dropped from CQD after 28 days
- Auto Attendant Identity
- Call Queue Identity
- VTC Device Name
- VTC Device Detail

Note: VTC fields are not yet documented at https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/blob/live/Teams/dimensions-and-measures-available-in-call-quality-dashboard.md 