### PR TITLE
Add note for multiple domains and autodiscover onprem Exchange-Teams-interact.md

### DIFF
--- a/Teams/Exchange-Teams-interact.md
+++ b/Teams/Exchange-Teams-interact.md
@@ -97,6 +97,9 @@ If mailboxes are hosted on-premises, to create and view meetings, the following 
 
 - Autodiscover and Exchange Web Services are published externally. For information about which Microsoft 365 services need access to on-premises Autodiscover and Exchange Web Services endpoints, see [Other endpoints not included in the Office 365 IP Address and URL Web service](/microsoft-365/enterprise/additional-office365-ip-addresses-and-urls).
 
+  > [!NOTE]
+  > Autodiscover endpoint is required for all primary email domains. The Autodiscover Domain feature in the Exchange Hybrid Configuration Wizard to force to use the Autodiscover information from a specific domain is not supported by Teams.
+
 - OAuth authentication is configured preferably via the Exchange Hybrid Configuration Wizard running a full hybrid configuration (Classic or Modern). If you are not able to use the Hybrid Configuration Wizard, configure OAuth as described in [Configure OAuth authentication between Exchange and Exchange Online organizations](/exchange/configure-oauth-authentication-between-exchange-and-exchange-online-organizations-exchange-2013-help).
 
   > [!NOTE]


### PR DESCRIPTION
@carolynblanding @dstrome, could you kindly confirm this information? It's not detailed in the article.

But from the following video:
https://www.youtube.com/watch?v=Uo_yOiQrolk&list=PLxdTT6-7g--2POisC5XcDQxUXHhWsoZc9&index=45&t=358s
 Process:
1. Teams sends JSON to Exchange Online
2. Exchange Online checks the recipient type
a) If it’s a mailbox, return:
https://outlook.office365.com/EWS/Exchange.asmx (Done!)
**b) It it’s mail user, calculate a DNS Autodiscover endpoint (based on 
ExternalEmailAddress) -> i.e., autodiscover.contoso.com or SRV Record**
3. EXO sends a HTTP 302 redirect including the endpoint URL
4. Teams sends JSON to the on-prem endpoint
5. Exchange on-prem returns EWS/REST URL

And I tested it in my lab.

It was also reported here:
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/4930
