### PR TITLE
Update set-up-your-team-hierarchy.md

### DIFF
--- a/Teams/set-up-your-team-hierarchy.md
+++ b/Teams/set-up-your-team-hierarchy.md
@@ -144,11 +144,8 @@ Los Angeles Store,West Regional Zone,204a1287-2efb-4a8a-88e0-56fbaf5a2389,Large,
 
 ## Apply your hierarchy
 
-> [!NOTE] 
-> To perform this step, you must install and use the Teams PowerShell public preview module from the PowerShell Gallery. For steps on how to install the module, see Install Teams PowerShell.
-
 > [!NOTE]
-> Government Community Cloud (GCC) customers must use [cmdlet preview version 2.4.0-preview](https://www.powershellgallery.com/packages/MicrosoftTeams/2.4.0-preview) or later to ensure data is routed to the GCC environment, rather than the public cloud environment.
+> To perform this step, you'll use "Microsoft Teams" PowerShell cmdlets. You can use version 4.6.0 or later of the Microsoft Teams cmdlets. This also applies for Government Community Cloud (GCC) customers.
 
 After you've defined your hierarchy in the schema CSV file, you're ready to upload it to Teams. To do this, run the following command. You must be a global admin or Teams service admin to do this step.
 
@@ -196,7 +193,7 @@ When confirming deletion, the status message will still display the previous sch
 ### Install the Teams PowerShell module
 
 > [!IMPORTANT]
-> To perform this step, you must install and use the Teams PowerShell public preview module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/MicrosoftTeams/). For steps on how to install the module, see [Install Teams PowerShell](teams-powershell-install.md).
+> To perform this step, you must install and use the Teams PowerShell module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/MicrosoftTeams/). For steps on how to install the module, see [Install Microsoft Teams PowerShell module](teams-powershell-install.md).
 
 ### Sample script
 

--- a/Teams/set-up-your-team-hierarchy.md
+++ b/Teams/set-up-your-team-hierarchy.md
@@ -145,7 +145,7 @@ Los Angeles Store,West Regional Zone,204a1287-2efb-4a8a-88e0-56fbaf5a2389,Large,
 ## Apply your hierarchy
 
 > [!NOTE]
-> To perform this step, you'll use "Microsoft Teams" PowerShell cmdlets. You can use version 4.6.0 or later of the Microsoft Teams cmdlets. This also applies for Government Community Cloud (GCC) customers.
+> To perform this step, you must use Microsoft Teams PowerShell cmdlets. You should use version 4.6.0 or later of the Microsoft Teams cmdlets. This also applies to Government Community Cloud (GCC) customers.
 
 After you've defined your hierarchy in the schema CSV file, you're ready to upload it to Teams. To do this, run the following command. You must be a global admin or Teams service admin to do this step.
 


### PR DESCRIPTION
2 Notes section at https://learn.microsoft.com/en-us/microsoftteams/set-up-your-team-hierarchy#apply-your-hierarchy referred to requirements for using Preview version of Teams PowerShell module. This capability is not in the release version, so this document is updated to reflect. 

additionally, the section "### Install the Teams PowerShell module" has reference to the preview module. Updated this as well and clarified some of the text.