### PR TITLE
Remove title rename limitation from private-channels.md

### DIFF
--- a/Teams/private-channels.md
+++ b/Teams/private-channels.md
@@ -127,8 +127,6 @@ Notifications from private channels are not included in missed activity emails.
 
 Channel meetings can't be scheduled.
 
-Channel meetings can't be customized with a meeting title.
-
 ## Related topics
 
 [Shared channels in Microsoft Teams](/MicrosoftTeams/shared-channels)


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/9429.

You can change the title like any other meeting:
![image](https://user-images.githubusercontent.com/33589238/201291929-4e711c77-4910-4546-856a-560e1a6ae70d.png)
