### PR TITLE
Typo "a Teams Room"→"the Teams Rooms"

### DIFF
--- a/Teams/includes/mtr-device-config-calendar-include.md
+++ b/Teams/includes/mtr-device-config-calendar-include.md
@@ -1,5 +1,5 @@
 
-To help your users more easily schedule meetings in the Teams Rooms, you can create room lists and places in Exchange Online. 
+To help your users more easily schedule meetings in Teams Rooms, you can create room lists and places in Exchange Online. 
 
 Exchange room lists and Outlook Places are used to control which resource accounts (and therefore the Teams Rooms they're associated with) appear in Outlook's Room Finder. Room Finder is an Outlook feature that helps users find rooms that are near them, available for reservation, and meet other criteria such as the availability of a display.
 

--- a/Teams/includes/mtr-device-config-calendar-include.md
+++ b/Teams/includes/mtr-device-config-calendar-include.md
@@ -1,11 +1,11 @@
 
-To help your users more easily schedule meetings in a Teams Room, you can create room lists and places in Exchange Online. 
+To help your users more easily schedule meetings in the Teams Rooms, you can create room lists and places in Exchange Online. 
 
 Exchange room lists and Outlook Places are used to control which resource accounts (and therefore the Teams Rooms they're associated with) appear in Outlook's Room Finder. Room Finder is an Outlook feature that helps users find rooms that are near them, available for reservation, and meet other criteria such as the availability of a display.
 
 Room lists are a special type of Exchange distribution group that let you group resource accounts (and therefore the Teams Rooms they're associated with) together in a meaningful way. For example, you might want to create room lists for all the rooms in each building on your campus.
 
-Outlook Places lets you set specific attributes about a resource account and its Teams Room. Some of the attributes you can set are:
+Outlook Places lets you set specific attributes about a resource account and its Teams Rooms. Some of the attributes you can set are:
 
 - Building
 - City


### PR DESCRIPTION
https://learn.microsoft.com/en-us/microsoftteams/hybrid-meetings-device-config-calendar 
https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/blob/live/Teams/includes/mtr-device-config-calendar-include.md 
#PingMSFTDocs