### PR TITLE
[METADATA UPDATE] Global metadata/header/navigation changes  

### DIFF
--- a/Teams/breadcrumb/toc.yml
+++ b/Teams/breadcrumb/toc.yml
@@ -1,3 +1,3 @@
 - name: Microsoft Teams
-  tocHref: /MicrosoftTeams/index
-  topicHref: /MicrosoftTeams/index
+  tocHref: /MicrosoftTeams/
+  topicHref: /MicrosoftTeams/

--- a/Teams/docfx.json
+++ b/Teams/docfx.json
@@ -43,7 +43,6 @@
         "Microsoft Teams"
       ],
       "breadcrumb_path": "/microsoftteams/breadcrumb/toc.json",
-      "extendBreadcrumb": false,
       "uhfHeaderId": "MSDocsHeader-MicrosoftTeams.yml",
       "ms.suite": "office",
       "titleSuffix": "Microsoft Teams",

--- a/Teams/docfx.json
+++ b/Teams/docfx.json
@@ -43,7 +43,7 @@
         "Microsoft Teams"
       ],
       "breadcrumb_path": "/microsoftteams/breadcrumb/toc.json",
-      "extendBreadcrumb": "false",
+      "extendBreadcrumb": false,
       "uhfHeaderId": "MSDocsHeader-MicrosoftTeams.yml",
       "ms.suite": "office",
       "titleSuffix": "Microsoft Teams",

--- a/Teams/docfx.json
+++ b/Teams/docfx.json
@@ -43,8 +43,8 @@
         "Microsoft Teams"
       ],
       "breadcrumb_path": "/microsoftteams/breadcrumb/toc.json",
-      "extendBreadcrumb": "true",
-      "uhfHeaderId": "MSDocsHeader-M365-IT",
+      "extendBreadcrumb": "false",
+      "uhfHeaderId": "MSDocsHeader-MicrosoftTeams.yml",
       "ms.suite": "office",
       "titleSuffix": "Microsoft Teams",
       "contributors_to_exclude": [


### PR DESCRIPTION
*High priority PR for navigation and breadcrumb compliance*  

This PR addresses required fixes to get content to basic compliance with site findability standards by 12/30/22. The progress of this effort is actively being reported to Scott Guthrie and his SLT in support of content quality initiatives. 
 

Standards for breadcrumbs:  

There are breadcrumbs on all TOCs 

Breadcrumbs link to the offering's root hub/landing page  

Breadcrumbs follow the pattern Learn / [Offering name] / [Sub-offering if applicable] 

 

Standards for headers: 

All content is using the correct L2 header for its offering 

 

If you think there is a mistake in this PR, please alert us immediately by emailing docsmetarequests@microsoft.com.  

 

--- 

 

A Pull Request has been made from the Learn Platform’s Metadata Management System. Please review and merge this Pull Request within 5 days. If you have any questions or concerns about the purpose of these metadata updates, please contact docsmetarequests@microsoft.com. If you are not the correct contact for this content and repository, please notify Learn-Metadata-Admin@microsoft.com.  

 

If this Pull Request is not merged within 14 days, it will be automatically merged by our system to ensure the timeliness of the metadata update. This includes bypassing the Repository’s Branch Policy, including if Review Required is enabled. Please notify Learn-Metadata-Admin@microsoft.com if you have questions or concerns or would like Pull Requests for metadata updates to merge automatically in future.  

 

Fixing: [High-profile ecosystem cleanup for content quality](https://dev.azure.com/ceapex/Engineering/_workitems/edit/751322) 

 

**Why we make header/navigation updates**  

Header changes and other site navigation updates are crucial for improving content findability and are made in support of the navigation model strategy driven by the Learn Information Architecture and Content Architecture teams.  

 

After you accept the header/navigation changes, you may now see a new or different product-level header used on content in your repo, revised breadcrumbs, or other navigation-related changes, which will be specified in the commit message.  

 

**Frequently Asked Questions**  

_Why does this Pull Request appear to be made by the Repository Owner?_ We open Pull Requests two different ways.   

For Git Repos with a permissioned Service Account, we open the PR from our Document Build Service Account.   

For Git Repos that we either do not have Service Account permission for or the repo is in Azure Repos (ADO)  we open the Pull Requests in an automated way with the PR creator as the Repo owner.  

 

_How can I revert a Pull Request that has been merged and created an unexpected issue?_ Whether a PR has been merged manually or automatically, you can revert it if an issue arises. See [Reverting a pull request - GitHub Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/reverting-a-pull-request). 