### PR TITLE
Update IP address range for media

### DIFF
--- a/Teams/direct-routing-plan-media-bypass.md
+++ b/Teams/direct-routing-plan-media-bypass.md
@@ -146,7 +146,7 @@ The table below summarizes the difference between Media Processors and Transport
 
 The IP ranges are:
 - 52.112.0.0/14 (IP addresses from 52.112.0.1 to 52.115.255.254)
-- 52.120.0.0/14 (IP addresses from 52.120.0.1 to 52.123.255.254)
+- 52.122.0.0/15 (IP addresses from 52.122.0.1 to 52.123.255.254)
 
 \* Transcoding explanation: 
 
@@ -195,7 +195,7 @@ You must place these three FQDNs in order to:
 
 The FQDNs **sip.pstnhub.microsoft.com**, **sip2.pstnhub.microsoft.com**, and **sip3.pstnhub.microsoft.com** will be resolved to IP addresses from the following subnets:
 - 52.112.0.0/14
-- 52.120.0.0/14
+- 52.122.0.0/15
 
 You need to open ports for all these IP ranges in your firewall to allow incoming and outgoing traffic to and from the addresses for signaling.
 

--- a/Teams/direct-routing-plan.md
+++ b/Teams/direct-routing-plan.md
@@ -280,7 +280,7 @@ The media traffic flows to and from a separate service in the Microsoft Cloud. T
 ### Microsoft 365, Office 365, and Office 365 GCC environments
 
 - 52.112.0.0/14 (IP addresses from 52.112.0.1 to 52.115.255.254).
-- 52.120.0.0/14 (IP addresses from 52.120.0.1 to 52.123.255.254).
+- 52.122.0.0/15 (IP addresses from 52.122.0.1 to 52.123.255.254).
 
 ### Office 365 DoD environment
 

--- a/Teams/direct-routing-whats-new.md
+++ b/Teams/direct-routing-whats-new.md
@@ -34,7 +34,7 @@ If no actions are taken before June 1, users won't be able to make or receive ca
 
 To prevent service impact:
 
-- Use the recommended subnets: (52.112.0.0/14 and 52.120.0.0/14) for any classification or ACL rules.
+- Use the recommended subnets: (52.112.0.0/14 and 52.122.0.0/15) for any classification or ACL rules.
 - Discontinue use of the sip-all FQDN when configuring Session Border Controls for  Direct Routing.
 
 For more information, see [Plan Direct Routing](direct-routing-plan.md).

--- a/Teams/set-up-phone-system-voicemail.md
+++ b/Teams/set-up-phone-system-voicemail.md
@@ -116,7 +116,7 @@ To create the auto-labeling policy to apply a sensitivity label to voicemail, se
 - Exchange rules:
   - Conditions:
     - **Header matches pattern**: Content-Class = Voice-CA
-    - **Sender IP address is**: 13.107.64.0/18, 52.112.0.0/14, 52.120.0.0/14, 52.238.119.141/32, 52.244.160.207/32
+    - **Sender IP address is**: 13.107.64.0/18, 52.112.0.0/14, 52.122.0.0/15, 52.238.119.141/32, 52.244.160.207/32
 
 - For **Choose a label to auto-apply**, select the sensitivity label you created for voicemail in the step above.
 


### PR DESCRIPTION
Update media IP address change. There was a change from `52.120.0.0/14` to `52.122.0.0/15` which was reflected for SIP signaling addresses, but missed for media IP address ranges. 