### PR TITLE
Update wording to "Microsoft eCDN"

### DIFF
--- a/Teams/teams-add-on-licensing/licensing-enhance-teams.md
+++ b/Teams/teams-add-on-licensing/licensing-enhance-teams.md
@@ -63,7 +63,7 @@ The following table compares key features between Teams and Teams Premium.
 | Read live translated captions during meetings |  | x |
 | Translate post-meeting transcriptions (*coming soon*) |  | x |
 | Turn on real-time data storage |  | x |
-| Turn on eCDN for Live Events |  | x |
+| Turn on [Microsoft eCDN](/ecdn/intro) for Live Events |  | x |
 
 ### Webinars
 


### PR DESCRIPTION
Added the mention of "Microsoft eCDN" (and link to corresponding doc) to avoid confusion with other 3rd party eCDN that do not require Teams Premium license