### PR TITLE
Fix table in direct-routing-translate-numbers.md

### DIFF
--- a/Teams/direct-routing-translate-numbers.md
+++ b/Teams/direct-routing-translate-numbers.md
@@ -61,7 +61,7 @@ The translation rules assigned to the SBC are summarized in the following table:
 |AddPlus1     |^(\d{10})$          |+1$1          |
 |AddE164SeattleAreaCode      |^(\d{4})$          | +1206555$1         |
 |AddSeattleAreaCode    |^(\d{4})$          | 425555$1         |
-|StripPlus1    |^+1(\d{10})$          | $1         |
+|StripPlus1    |^\+1(\d{10})$          | $1         |
 
 In the following examples, there are two users, Alice and Bob. Alice is a Teams user whose number is +1 206 555 0100. Bob is a PSTN user whose number is +1 425 555 0100.
 


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/issues/9566.

Source: https://learn.microsoft.com/powershell/module/skype/new-csteamstranslationrule