### PR TITLE
Update hybrid-meetings-device-select.md

### DIFF
--- a/Teams/hybrid-meetings-device-select.md
+++ b/Teams/hybrid-meetings-device-select.md
@@ -68,6 +68,7 @@ When considering a display, look at its specifications to find out what size roo
 The following are examples of displays for Teams Rooms:
 
 - [Epson EB-PU1007B projector](https://epson.com/For-Work/Projectors/Large-Venue/EB-PU1007B-WUXGA-3LCD-Laser-Projector-with-4K-Enhancement/p/V11HA34820)
+- [Jupiter PANA105D 105" 21:9 display](https://www.jupiter.com/pana105/)
 - [Samsung QM85R-B 85" display](https://displaysolutions.samsung.com/digital-signage/detail/1944/QM85R-B)
 
 ## Sound bars

--- a/Teams/hybrid-meetings-device-select.md
+++ b/Teams/hybrid-meetings-device-select.md
@@ -68,7 +68,7 @@ When considering a display, look at its specifications to find out what size roo
 The following are examples of displays for Teams Rooms:
 
 - [Epson EB-PU1007B projector](https://epson.com/For-Work/Projectors/Large-Venue/EB-PU1007B-WUXGA-3LCD-Laser-Projector-with-4K-Enhancement/p/V11HA34820)
-- [Jupiter PANA105D 105" 21:9 display](https://www.jupiter.com/pana105/)
+- [Jupiter Pana 105D 105" 21:9 display](https://www.jupiter.com/pana105/)
 - [Samsung QM85R-B 85" display](https://displaysolutions.samsung.com/digital-signage/detail/1944/QM85R-B)
 
 ## Sound bars


### PR DESCRIPTION
Hi I noticed that the Jupiter PANA105D display that is used in almost all of the Signature Rooms at MS offices was not listed under displays. Since its the only LCD that is FrontRow ready (21:9 5K) and it is the one that is used by MS offices it is probably worth listing.