### PR TITLE
Remove support note on mailbox hosted on-premises.

### DIFF
--- a/Teams/Exchange-Teams-interact.md
+++ b/Teams/Exchange-Teams-interact.md
@@ -84,9 +84,6 @@ Microsoft Teams works with several Microsoft 365 and Office 365 services to prov
 
 ## Requirements to create and view meetings for mailboxes hosted on-premises
 
-  > [!NOTE]
-  > The **Create and view meetings for mailboxes hosted on-premises** feature is only supported within commercial, GCC, and GCC High environments.
-
 If mailboxes are hosted on-premises, to create and view meetings, the following requirements must be met:
 
 - The required Teams license needs to be assigned for the Azure Active Directory synced user.


### PR DESCRIPTION
Support for mailboxes hosted on-premises does not have limitations based on any of the M365 environments: GCC,GCCH,DOD