### PR TITLE
Customer request to clarify live captions availability.

### DIFF
--- a/Teams/teams-add-on-licensing/licensing-enhance-teams.md
+++ b/Teams/teams-add-on-licensing/licensing-enhance-teams.md
@@ -57,7 +57,7 @@ The following table compares key features between Teams and Teams Premium.
 | Host and attend Teams Meetings | x | x |
 | Experience Teams’ standard look and feel | x | x |
 | Use standard and custom meeting backgrounds at the user level| x | x |
-| Read live captions during meetings | x | x |
+| Read live captions during meetings and live events | x | x |
 | Customize meeting templates for your organization |  | x |
 | Add organization branding to meeting lobbies |  | x |
 | Customize meeting backgrounds for your organization | | x |


### PR DESCRIPTION
An S500 customer is requesting an update to the article to explicitly state that translated live captions for Live events does not require a Teams Premium license. Currently the capability exists for years within TLEs.