### PR TITLE
Update third-party-join.md

### DIFF
--- a/Teams/rooms/third-party-join.md
+++ b/Teams/rooms/third-party-join.md
@@ -136,3 +136,7 @@ To configure Teams Rooms on Android using the touchscreen console or front-of-ro
 
 3. Select a third-party meeting provider you want to enable.
 4. If you want to join meetings with a custom username and email address, select **Join with custom name and email**. To update custom personal info, press **Edit custom info** and input your preferred name and email address.
+
+
+
+[!NOTE] If you want to join Teams meetings from third-party devices, please work with your device provider. Keep in mind that joining Teams meetings in GCC or GCCH is not supported. 

--- a/Teams/rooms/third-party-join.md
+++ b/Teams/rooms/third-party-join.md
@@ -137,6 +137,4 @@ To configure Teams Rooms on Android using the touchscreen console or front-of-ro
 3. Select a third-party meeting provider you want to enable.
 4. If you want to join meetings with a custom username and email address, select **Join with custom name and email**. To update custom personal info, press **Edit custom info** and input your preferred name and email address.
 
-
-
-[!NOTE] If you want to join Teams meetings from third-party devices, please work with your device provider. Keep in mind that joining Teams meetings in GCC or GCCH is not supported. 
+[!NOTE] If you want to join Teams meetings from third-party devices, you should work with your device provider. Keep in mind that joining Teams meetings in GCC or GCCH is not supported. 


### PR DESCRIPTION
Adding a note clarifying we do not support GCC and GCCH Teams meetings on 3P devices. This note should be a note at the end of the document since it is for 3P devices and the document is focused on Teams Rooms. It should be a note in purple that can be seen as independent of the content of the document. ping me in teams to naforer if you have any questions