### PR TITLE
Rooms-lifecycle-support.md Windows 11 cutover

### DIFF
--- a/Teams/rooms/rooms-lifecycle-support.md
+++ b/Teams/rooms/rooms-lifecycle-support.md
@@ -60,7 +60,7 @@ The following table shows recommended and supported versions of Windows that are
 | 1709    | 2018-01-18        | Not supported                                           | &#x2014;                                          | &#x2014;             |
 | 1703    | 2017-07-11        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
 
-&#x2780; In order to maximize service life, hardware that is not Windows 11 eligible will upgrade from Windows 10 21H2 to Windows 10 22H2. Please take note of the [Windows 10 IoT Enterprise end of support date](https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-enterprise).
+&#x2780; In order to maximize service life, hardware that is not Windows 11 eligible will upgrade from Windows 10 21H2 to Windows 10 22H2. Please take note of the [Windows 10 IoT Enterprise end of support date](https://learn.microsoft.com/lifecycle/products/windows-10-iot-enterprise).
 
 &#x2781; Windows 10 version 2004 is not recommended due to compatibility issues found with the Microsoft Teams Rooms application. This specific issue causes the Microsoft Teams Rooms application to fail to start after the nightly reboot.
 

--- a/Teams/rooms/rooms-lifecycle-support.md
+++ b/Teams/rooms/rooms-lifecycle-support.md
@@ -31,37 +31,40 @@ All releases are listed in the [Microsoft Teams Rooms release notes](rooms-relea
 > [!IMPORTANT]
 > When installing a new device that came with an older version of the Teams room application, it is recommended to [manually update the application](manual-update.md) after setting the account, before downloading any Windows updates. This ensures correct OS version and Windows updates are installed on your device.  
 
-## Windows 10 release support
+## Windows release support
 
-Microsoft Teams Rooms requires the  Windows 10 IoT Enterprise or Windows 10 Enterprise SKUs under Semi-Annual Channel servicing options. These other Windows 10 editions aren't supported:
+Microsoft Teams Rooms requires the  Windows IoT Enterprise or Windows Enterprise SKUs under the Global Availability Channel servicing option. These other Windows editions aren't supported:
 
-- Windows 10 Enterprise Long-term Servicing Branch (LTSB) / Long Term Servicing Channel (LTSC) editions
-- Windows 10 Internet of Things (IoT) Enterprise LTSB / LTSC editions
-- any other edition of Windows such as Windows 10 Pro or Home edition
+- Windows Enterprise Long-term Servicing Branch (LTSB) / Long Term Servicing Channel (LTSC) editions
+- Windows Internet of Things (IoT) Enterprise LTSB / LTSC editions
+- any other edition of Windows such as Windows Pro or Home edition
 
-New Windows 10 feature updates aren't offered on Microsoft Teams Rooms devices immediately. There's an intentional delay of up to six months or more after the general availability date published on the [Windows 10 release information](/windows/release-information/) page. This time is used to validate Windows 10 release compatibility for the Microsoft Teams Rooms app, device hardware, and certified audio video peripherals. Validation begins and continues during active development of each major release of Windows 10. Extra time is needed to validate that all device manufacturers have built updated images for their devices, and for Microsoft to certify and test those images. During the validation period, the Microsoft Teams Rooms app uses [Windows Update for Business group policies](/windows/deployment/update/waas-manage-updates-wufb) to delay Windows 10 feature updates. After any compatibility issues are found and resolved, the block is lifted via updating group policies through a new app release in Windows store. Devices that run the Microsoft Teams Rooms app automatically update to an appropriate Windows 10 release during the nightly maintenance reboot. An MSI version is made available for customers that need to manually manage updates.  
+New Windows feature updates aren't offered on Microsoft Teams Rooms devices immediately. There's an intentional delay of up to six months or more after the general availability date published on the [Windows release information](/windows/release-information/) page. This time is used to validate Windows release compatibility for the Microsoft Teams Rooms app, device hardware, and certified audio video peripherals. Validation begins and continues during active development of each major release of Windows. Extra time is needed to validate that all device manufacturers have built updated images for their devices, and for Microsoft to certify and test those images. During the validation period, the Microsoft Teams Rooms app uses [Windows Update for Business group policies](/windows/deployment/update/waas-manage-updates-wufb) to delay Windows feature updates. After any compatibility issues are found and resolved, the block is lifted via updating group policies through a new app release in Windows store. Devices that run the Microsoft Teams Rooms app automatically update to an appropriate Windows release during the nightly maintenance reboot. An MSI version is made available for customers that need to manually manage updates.  
 
 > [!IMPORTANT]
-> During the validation period, Microsoft Teams Rooms devices should **not** be updated to the next release of Windows 10 by any means. This includes overriding the group policies in place, or using System Center or other third-party device management services. Any of these may cause issues for the Microsoft Teams Rooms app or may leave devices unusable.  
+> During the validation period, Microsoft Teams Rooms devices should **not** be updated to the next release of Windows by any means. This includes overriding the group policies in place, or using System Center or other third-party device management services. Any of these may cause issues for the Microsoft Teams Rooms app or may leave devices unusable.  
 
-The following table shows recommended and supported versions of Windows 10 that are verified to support Microsoft Teams Rooms. All dates are listed in ISO 8601 format: YYYY-MM-DD.
+The following table shows recommended and supported versions of Windows that are verified to support Microsoft Teams Rooms. All dates are listed in ISO 8601 format: YYYY-MM-DD.
 
 | Version | Availability date | Microsoft Teams Rooms support status                    | Microsoft Teams Rooms Minimum application version | Recommended OS build |
 |:--------|:------------------|:--------------------------------------------------------|:--------------------------------------------------|:---------------------|
-| 21H2    | 2021-11-16        | Supported,<br>Recommended                               | 4.12.126.0                                        | 19044.1288           |
+| 22H2    | 2022-10-18        | Supported,<br>Recommended                               | 4.16.134.0                                        | 22621.525 &#x2780;  |
+| 21H2    | 2021-11-16        | Supported                                               | 4.12.126.0                                        | 19044.1288           |
 | 21H1    | 2021-05-18        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
-| 20H2    | 2020-10-20        | Supported                                               | 4.10.10.0                                         | 19042.631            |
-| 2004    | 2020-05-27        | Not Supported, <br/>Known compatibility issues  &#x2780;| &#x2014;                                          | &#x2014;             |
+| 20H2    | 2020-10-20        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
+| 2004    | 2020-05-27        | Not Supported, <br/>Known compatibility issues  &#x2781;| &#x2014;                                          | &#x2014;             |
 | 1909    | 2019-11-12        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
 | 1903    | 2019-05-21        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
-| 1809    | 2019-03-28        | Not Supported, <br/>Known compatibility issues &#x2781; | &#x2014;                                          | &#x2014;             |
+| 1809    | 2019-03-28        | Not Supported, <br/>Known compatibility issues &#x2782; | &#x2014;                                          | &#x2014;             |
 | 1803    | 2018-07-10        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
 | 1709    | 2018-01-18        | Not supported                                           | &#x2014;                                          | &#x2014;             |
 | 1703    | 2017-07-11        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
 
-&#x2780; Windows 10 version 2004 is not recommended due to compatibility issues found with the Microsoft Teams Rooms application. This specific issue causes the Microsoft Teams Rooms application to fail to start after the nightly reboot.
+&#x2780; In order to maximize service life, hardware that is not Windows 11 eligible will upgrade from Windows 10 21H2 to Windows 10 22H2. Please take note of the [Windows 10 IoT Enterprise end of support date](https://learn.microsoft.com/en-us/lifecycle/products/windows-10-iot-enterprise).
 
-&#x2781; Windows 10 version 1809 is not recommended due to compatibility issues found with the Microsoft Teams Rooms application. This specific issue causes the Microsoft Teams Rooms application to fail to start after the nightly reboot. This issue was addressed in  Windows 10 version 1903.  
+&#x2781; Windows 10 version 2004 is not recommended due to compatibility issues found with the Microsoft Teams Rooms application. This specific issue causes the Microsoft Teams Rooms application to fail to start after the nightly reboot.
+
+&#x2782; Windows 10 version 1809 is not recommended due to compatibility issues found with the Microsoft Teams Rooms application. This specific issue causes the Microsoft Teams Rooms application to fail to start after the nightly reboot. This issue was addressed in  Windows 10 version 1903.  
 
 When you use a supported version of Windows 10, you will always get the latest application updates for the Microsoft Teams Rooms app.  
 

--- a/Teams/rooms/rooms-lifecycle-support.md
+++ b/Teams/rooms/rooms-lifecycle-support.md
@@ -60,7 +60,7 @@ The following table shows recommended and supported versions of Windows that are
 | 1709    | 2018-01-18        | Not supported                                           | &#x2014;                                          | &#x2014;             |
 | 1703    | 2017-07-11        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
 
-&#x2780; In order to maximize service life, hardware that is not Windows 11 eligible will upgrade from Windows 10 21H2 to Windows 10 22H2. Please take note of the [Windows 10 IoT Enterprise end of support date](https://learn.microsoft.com/lifecycle/products/windows-10-iot-enterprise).
+&#x2780; In order to maximize service life, hardware that is not Windows 11 eligible will upgrade from Windows 10 21H2 to Windows 10 22H2. Please take note of the [Windows 10 IoT Enterprise end of support date](/lifecycle/products/windows-10-iot-enterprise).
 
 &#x2781; Windows 10 version 2004 is not recommended due to compatibility issues found with the Microsoft Teams Rooms application. This specific issue causes the Microsoft Teams Rooms application to fail to start after the nightly reboot.
 

--- a/Teams/rooms/rooms-lifecycle-support.md
+++ b/Teams/rooms/rooms-lifecycle-support.md
@@ -60,7 +60,7 @@ The following table shows recommended and supported versions of Windows that are
 | 1709    | 2018-01-18        | Not supported                                           | &#x2014;                                          | &#x2014;             |
 | 1703    | 2017-07-11        | Not Supported                                           | &#x2014;                                          | &#x2014;             |
 
-&#x2780; In order to maximize service life, hardware that is not Windows 11 eligible will upgrade from Windows 10 21H2 to Windows 10 22H2. Please take note of the [Windows 10 IoT Enterprise end of support date](/lifecycle/products/windows-10-iot-enterprise).
+&#x2780; In order to maximize service life, hardware that is not Windows 11 eligible will upgrade from Windows 10 21H2 to Windows 10 22H2. However, take note of the [Windows 10 IoT Enterprise end of support date](/lifecycle/products/windows-10-iot-enterprise).
 
 &#x2781; Windows 10 version 2004 is not recommended due to compatibility issues found with the Microsoft Teams Rooms application. This specific issue causes the Microsoft Teams Rooms application to fail to start after the nightly reboot.
 

--- a/Teams/rooms/rooms-release-note.md
+++ b/Teams/rooms/rooms-release-note.md
@@ -60,7 +60,7 @@ Introduced in this update:
 - Windows 10 22H2 support for Windows 11 ineligible devices
 
 > [!IMPORTANT]
-> Please use the [manual update](manual-update.md) instructions if you would like to evaluate the Windows 11 upgrade. This release is optional. The next release of the app will contain this change, and will automatically install the most up-to-date supported version of Windows.
+> Use the [manual update](manual-update.md) instructions if you would like to evaluate the Windows 11 upgrade. This release is optional. The next release of the app will contain this change, and will automatically install the most up-to-date supported version of Windows.
 
 
 ### 4.16.40.0 (3/24/2023)

--- a/Teams/rooms/rooms-release-note.md
+++ b/Teams/rooms/rooms-release-note.md
@@ -52,6 +52,17 @@ Teams Rooms is governed by the Modern Lifecycle Policy. For more information, se
 
 Teams Rooms app updates happen either via the Microsoft Store or via [manual update](manual-update.md). Updates are applied to the Universal Windows Platform (UWP) application that is installed locally on the device.
 
+### 4.16.134.0 (5/8/2023) - Manual Update Only
+
+Introduced in this update:
+
+- Windows 11 support
+- Windows 10 22H2 support for Windows 11 ineligible devices
+
+> [!IMPORTANT]
+> Please use the [manual update](manual-update.md) instructions if you would like to evaluate the Windows 11 upgrade. This release is optional. The next release of the app will contain this change, and will automatically install the most up-to-date supported version of Windows.
+
+
 ### 4.16.40.0 (3/24/2023)
 
 Introduced in this update:

--- a/Teams/rooms/rooms-release-note.md
+++ b/Teams/rooms/rooms-release-note.md
@@ -246,7 +246,7 @@ Introduced in this update:
 - Windows 10 20H2 support
 
 > [!NOTE]
-> Crestron UC-Engine (BIOS version date containing "KYSKLi") Teams Rooms have compatibility issues and updated drivers will be provided by system OEMs in the near future. Windows 10 20H2 won't be offered to these devices. For more information about Windows version support, see [Windows 10 release support](./rooms-lifecycle-support.md#windows-release-support).
+> Crestron UC-Engine (BIOS version date containing "KYSKLi") Teams Rooms have compatibility issues and updated drivers will be provided by system OEMs in the near future. Windows 10 20H2 won't be offered to these devices. For more information about Windows version support, see [Windows release support](./rooms-lifecycle-support.md#windows-release-support).
 
 ### 4.8.25.0 (04/22/2021)
 
@@ -323,7 +323,7 @@ Introduced in this update:
 - Search and call federated users (tenant) from Teams Room
 
 > [!IMPORTANT]
-> Version 4.5 is last release to support Windows 10 version 1803; future releases will not be offered to systems on Windows 10 version 1803. For more information about Windows version support, see [Windows 10 release support](./rooms-lifecycle-support.md#windows-release-support).
+> Version 4.5 is last release to support Windows 10 version 1803; future releases will not be offered to systems on Windows 10 version 1803. For more information about Windows version support, see [Windows release support](./rooms-lifecycle-support.md#windows-release-support).
 
 ### 4.4.63.0 (06/25/2020)
 

--- a/Teams/rooms/rooms-release-note.md
+++ b/Teams/rooms/rooms-release-note.md
@@ -52,7 +52,7 @@ Teams Rooms is governed by the Modern Lifecycle Policy. For more information, se
 
 Teams Rooms app updates happen either via the Microsoft Store or via [manual update](manual-update.md). Updates are applied to the Universal Windows Platform (UWP) application that is installed locally on the device.
 
-### 4.16.134.0 (5/8/2023) - Manual Update Only
+### 4.16.134.0 (5/8/2023) - Manual update only
 
 Introduced in this update:
 

--- a/Teams/rooms/rooms-release-note.md
+++ b/Teams/rooms/rooms-release-note.md
@@ -246,7 +246,7 @@ Introduced in this update:
 - Windows 10 20H2 support
 
 > [!NOTE]
-> Crestron UC-Engine (BIOS version date containing "KYSKLi") Teams Rooms have compatibility issues and updated drivers will be provided by system OEMs in the near future. Windows 10 20H2 won't be offered to these devices. For more information about Windows version support, see [Windows 10 release support](./rooms-lifecycle-support.md#windows-10-release-support).
+> Crestron UC-Engine (BIOS version date containing "KYSKLi") Teams Rooms have compatibility issues and updated drivers will be provided by system OEMs in the near future. Windows 10 20H2 won't be offered to these devices. For more information about Windows version support, see [Windows 10 release support](./rooms-lifecycle-support.md#windows-release-support).
 
 ### 4.8.25.0 (04/22/2021)
 
@@ -323,7 +323,7 @@ Introduced in this update:
 - Search and call federated users (tenant) from Teams Room
 
 > [!IMPORTANT]
-> Version 4.5 is last release to support Windows 10 version 1803; future releases will not be offered to systems on Windows 10 version 1803. For more information about Windows version support, see [Windows 10 release support](./rooms-lifecycle-support.md#windows-10-release-support).
+> Version 4.5 is last release to support Windows 10 version 1803; future releases will not be offered to systems on Windows 10 version 1803. For more information about Windows version support, see [Windows 10 release support](./rooms-lifecycle-support.md#windows-release-support).
 
 ### 4.4.63.0 (06/25/2020)
 

--- a/Teams/rooms/update-management.md
+++ b/Teams/rooms/update-management.md
@@ -42,7 +42,7 @@ Most unexpected failures arise from changes in the base image with uncertain his
 Following simple readiness checks is recommended:  
 
 - **Base Image**: The base image must be from the specific OEM. If the device has been rebuilt in the past and shows unexpected failures or behaviors on common tasks, the base image must be restored. We can provide assistance but cannot remotely rebuild the room device, so you will need a local site technician.  
-- **Base OS, Edition:** The base OS and edition must match the requirements of Microsoft Teams Rooms devices. If this is not so, it must be corrected as part of onboarding. Microsoft Teams Rooms requires the Windows 10 IoT Enterprise or Windows 10 Enterprise SKUs under Semi-Annual Channel servicing options. Consult the official [MTR guidance](rooms-lifecycle-support.md#windows-10-release-support) for more information.
+- **Base OS, Edition:** The base OS and edition must match the requirements of Microsoft Teams Rooms devices. If this is not so, it must be corrected as part of onboarding. Microsoft Teams Rooms requires the Windows IoT Enterprise or Windows Enterprise SKUs under Semi-Annual Channel servicing options. Consult the official [MTR guidance](rooms-lifecycle-support.md#windows-release-support) for more information.
 
 ## Readiness checks
 


### PR DESCRIPTION
- Remove references to Windows 10 in most places.
- Update 20H2 to no longer be supported
- Update 21H2 to be supported, but no longer recommended
- Add 22H2 as the new supported, recommended build
- Add callout for Windows 11 ineligible hardware, 22H2, and the upcoming end of life for Windows 10.