### PR TITLE
Fixed typo in heading - changed user to used

### DIFF
--- a/Teams/teams-encoder-setup.md
+++ b/Teams/teams-encoder-setup.md
@@ -34,7 +34,7 @@ The workflow for producing a Teams Live Event is as follows:
 
 A live event is scheduled in Teams or Yammer, and the **Teams Encoder** option is selected. This provisions an RTMP endpoint, which is provided with an RTMP(S) URL and corresponding key. The URL and key are used by the encoder to connect to the RTMP endpoint for the scheduled live event.
 
-### Common encoders user with live events
+### Common encoders used with live events
 
 The encoders in the following two lists have been tested by Microsoft for live streaming with Teams. The first list is a subset of these encoders, which have been tested with the product for ease of use and quick setup.
 


### PR DESCRIPTION
Fixed typo in heading 
From
Common encoders user with live events
To 
Common encoders used with live events