### PR TITLE
Update private-channels.md

### DIFF
--- a/Teams/private-channels.md
+++ b/Teams/private-channels.md
@@ -46,7 +46,7 @@ By default, any team owner or team member can create a private channel. Guests c
 
 The person who creates a private channel is the private channel owner and only the private channel owner can directly add or remove people from it. A private channel owner can add any team member to a private channel they created, including guests. Members of a private channel have a secure conversation space, and when new members are added, they can see all conversations (even old conversations) in that private channel.
 
-Team owners can see the names of all private channels in their team and can also delete any private channel in the team. (A deleted private channel can be restored within 30 days after it's deleted). Team owners can't see the files in a private channel or the conversations and member list of a private channel unless they're members of that private channel.
+Team owners can't see the names of private channels in their team that they are not members of or that they don't own. A private channel owner or team owner who is a member of the private channel can delete the private channel in the team. (A deleted private channel can be restored within 30 days after it's deleted). Team owners can't see the channels, files in a private channel, or the conversations and member list of a private channel unless they're members of that private channel.
 
 Team members can only see private channels that they've been added to.
 

--- a/Teams/private-channels.md
+++ b/Teams/private-channels.md
@@ -46,7 +46,7 @@ By default, any team owner or team member can create a private channel. Guests c
 
 The person who creates a private channel is the private channel owner and only the private channel owner can directly add or remove people from it. A private channel owner can add any team member to a private channel they created, including guests. Members of a private channel have a secure conversation space, and when new members are added, they can see all conversations (even old conversations) in that private channel.
 
-Team owners can't see the names of private channels in their team that they are not members of or that they don't own. A private channel owner or team owner who is a member of the private channel can delete the private channel in the team. (A deleted private channel can be restored within 30 days after it's deleted). Team owners can't see the channels, files in a private channel, or the conversations and member list of a private channel unless they're members of that private channel.
+Team owners can only see private channels in their team if they are owners or members of the channel. A private channel owner or team owner who is a member of the private channel can delete the private channel. (A deleted private channel can be restored within 30 days after it's deleted).
 
 Team members can only see private channels that they've been added to.
 


### PR DESCRIPTION
Updated the document according to how this currently works. 

Team owners **can't see the names of private channels in their team that they are not members of or that they don't own**. A private channel owner or team owner who is a member of the private channel can delete the private channel in the team. (A deleted private channel can be restored within 30 days after it's deleted). Team owners can't see the channels, files in a private channel, or the conversations and member list of a private channel unless they're members of that private channel.