### PR TITLE
Update new-teams-known-issues.md

### DIFF
--- a/Teams/new-teams-known-issues.md
+++ b/Teams/new-teams-known-issues.md
@@ -28,7 +28,7 @@ ms.localizationpriority: high
 - Scheduling a Teams Live Event will redirect to the classic Teams web experience currently.
 - Producing a Teams Live Event is not currently available; you will need to switch back to classic Teams.
 - Setting up the Home Page in a newly created Class team in Microsoft Teams for Education isn't currently available on desktop.
-- Adding a sensitivity label during team creation is currently not available in Teams for Education
+- Adding a sensitivity label during team creation is currently not available in Teams for Education.
 
 ## Coming in November
 

--- a/Teams/new-teams-known-issues.md
+++ b/Teams/new-teams-known-issues.md
@@ -28,6 +28,7 @@ ms.localizationpriority: high
 - Scheduling a Teams Live Event will redirect to the classic Teams web experience currently.
 - Producing a Teams Live Event is not currently available; you will need to switch back to classic Teams.
 - Setting up the Home Page in a newly created Class team in Microsoft Teams for Education isn't currently available on desktop.
+- Adding a sensitivity label during team creation is currently not available in Teams for Education
 
 ## Coming in November
 


### PR DESCRIPTION
Added a known issue where sensitivity labels cannot be added during team creation in Teams for Education. Will move to the appropriate "Coming in..." section once the ETA is confirmed.