### PR TITLE
Update known issues for Teams

### DIFF
--- a/Teams/new-teams-known-issues.md
+++ b/Teams/new-teams-known-issues.md
@@ -34,6 +34,7 @@ ms.localizationpriority: high
 - Support for NDI, SDI, and ISO streaming of Teams media content.
 - Set presence in taskbar.
 - Show and set presence in system tray.
+- Unable to configure incoming webhooks on private channels
 
 ## Issues specifically for the new Microsoft Teams for Education
 


### PR DESCRIPTION
- [chore]: Add known issue: Unable to configure incoming webhooks on private channels
- Per Office 365 Support: "An enhancement task has been opened internally, our product team is working on a fix with an ETA between January and early February. In the meantime, we recommend adding incoming webhooks to the channels through the existing option in Teams web."
