### PR TITLE
Update limits-specifications-teams.md

### DIFF
--- a/Teams/limits-specifications-teams.md
+++ b/Teams/limits-specifications-teams.md
@@ -185,18 +185,18 @@ Live events are structured meetings that enable your organization to schedule an
 |Duration of event | 4 hours |
 |Concurrent Live Events running in a Microsoft 365 or Office 365 organization <sup>2</sup> | 50<sup>3</sup> |
 
-<sup>1</sup>  The usual 10,000 is increased to 20,000 through December 31, 2023. You can schedule even greater numbers with live events in Viva Engage and/or Microsoft Stream. For more information, see [Live events across Microsoft 365](/stream/live-event-m365). Events over 20,000 attendees require the [Live Events Assistance Program](/stream/live-events-assistance).
+<sup>1</sup>  The usual 10,000 is increased to 20,000 through June 30, 2024. You can schedule even greater numbers with live events in Viva Engage and/or Microsoft Stream. For more information, see [Live events across Microsoft 365](/stream/live-event-m365). Events over 20,000 attendees require the [Live Events Assistance Program](/stream/live-events-assistance).
 
 <sup>2</sup> You can schedule as many Live Events as you want, but you can only run 15 at a time. As soon as the producer joins a live event, it's considered to be running. The producer who attempts to join the 16th live event gets an error.
 
-<sup>3</sup>  The usual 15 is increased to 50 through December 31, 2023.
+<sup>3</sup>  The usual 15 is increased to 50 through June 30, 2024.
 
 For more information about live events, go to [Teams live events](teams-live-events/plan-for-teams-live-events.md#teams-live-events). See also [Schedule a Teams live event](https://support.microsoft.com/office/schedule-a-live-event-in-microsoft-teams-7a9ce97c-e1cd-470f-acaf-e6dfc179a0e2).
 
 > [!IMPORTANT]
 > **Microsoft 365 live event limit increases**
 >
-> **To continue supporting our customers' needs, we will extend temporary limit increases for live events through December 31, 2023, including:**
+> **To continue supporting our customers' needs, we will extend temporary limit increases for live events through June 30, 2024, including:**
 >
 >- Event support for up to 20,000 attendees
 >- 50 events can be hosted simultaneously across a tenant


### PR DESCRIPTION
Updated the previous Teams Live Event capacity limit end date from December 31, 2023, to June 30, 2024 per the MC698896 published on December 16, 2023.