### PR TITLE
Update plan-for-teams-live-events.md

### DIFF
--- a/Teams/teams-live-events/plan-for-teams-live-events.md
+++ b/Teams/teams-live-events/plan-for-teams-live-events.md
@@ -100,7 +100,7 @@ The following table highlights core capabilities and features offered in live ev
 > [!IMPORTANT]
 > **Microsoft 365 live event limit increases**
 >
-> **To continue supporting our customers' needs, we will extend temporary limit increases for live events through December 31, 2023, including:**
+> **To continue supporting our customers' needs, we will extend temporary limit increases for live events through June 30, 2024, including:**
 >
 >- Event support for up to 20,000 attendees
 >- 50 events can be hosted simultaneously across a tenant


### PR DESCRIPTION
Updated the Teams Live Events capacity limit extension end date from December 31, 2023 to June 30, 2024 per MC698896.