### PR TITLE
Update pstn-usage-report.md retention table (removing DE, correcting UK --> GB)

### DIFF
--- a/Teams/teams-analytics-and-reports/pstn-usage-report.md
+++ b/Teams/teams-analytics-and-reports/pstn-usage-report.md
@@ -116,7 +116,6 @@ Per-country regulatory requirements specify data retention of detailed call reco
 | :---: | :--- | :--- |
 | CA – Canada | 150 | 150 |
 | CH – Switzerland | 365 | 365 |
-| DE – Germany | 365 | 100 |
 | DK – Denmark | 365 | 365 |
 | FI – Finland | 365 | 365 |
 | FR – France | 365 | 365 |
@@ -126,7 +125,7 @@ Per-country regulatory requirements specify data retention of detailed call reco
 | NL – Netherlands | 180 | 180 |
 | NO – Norway | 150 | 150 |
 | SE – Sweden | 180 | 180 |
-| UK – United Kingdom | 450 | 450 |
+| GB – Great Britain | 450 | 450 |
 | All other countries | 365 | 150 |
 
 Note that these rules apply to the PSTN and Direct Routing reports in Tenant Admin Center, data export, and the PSTN and Direct Routing call logs available via Microsoft Graph. Data retention in other reports, such as Call Analytics and Call Quality Dashboard, may differ.


### PR DESCRIPTION
Retention table has incorrect information for DE (the retention is the same as "All other countries"), correcting UK to GB per ISO 3166-1 alpha-2 standard.