### PR TITLE
Update new-teams-known-issues.md

### DIFF
--- a/Teams/new-teams-known-issues.md
+++ b/Teams/new-teams-known-issues.md
@@ -38,6 +38,7 @@ ms.localizationpriority: high
 - When editing a TLE on the web, users can't use the **Manage live event resources** link at the bottom of the page. Selecting the link redirects the user to a different page. Resources for the event, can be found at the top of the page.
 - The **Manage live event resources** link in the calendar invite doesn't work outside of Teams. Users must open the invite in Teams calendar to edit the session and access event resources.
 - If a user closes a TLE session on the web, the next time they open Teams on the web, Teams might try and relaunch the last TLE event the user was in.
+- The app will crash on startup with the error APPLICATION_FAULT_c06d007e_PvDSSource64.ax if the Pleora Technologies eBUS SDK is installed. Update to the latest version of the SDK or uninstall.
 
 ## Issues specifically for the new Microsoft Teams for Education
 


### PR DESCRIPTION
The app will crash on startup with the error APPLICATION_FAULT_c06d007e_PvDSSource64.ax if the Pleora Technologies eBUS SDK is installed. Update to the latest version of the SDK or uninstall.