### PR TITLE
Update info on the Media bit rate policy in meeting-policies-audio-and-video.md

### DIFF
--- a/Teams/meeting-policies-audio-and-video.md
+++ b/Teams/meeting-policies-audio-and-video.md
@@ -140,6 +140,8 @@ If there isn't enough bandwidth for a meeting, participants see a message that i
 
 For meetings that need the highest-quality video experience, such as CEO board meetings and Teams live events, we recommend you set the bandwidth to 10 Mbps. Even when the maximum experience is set, Teams adapts to low-bandwidth conditions when certain network conditions are detected, depending on the scenario.
 
+The Media bit rate policy does not affect the Teams Web Client.
+
 ## Participants can use video effects
 
 <a name="bkvideofilters"> </a>

--- a/Teams/meeting-policies-audio-and-video.md
+++ b/Teams/meeting-policies-audio-and-video.md
@@ -140,7 +140,7 @@ If there isn't enough bandwidth for a meeting, participants see a message that i
 
 For meetings that need the highest-quality video experience, such as CEO board meetings and Teams live events, we recommend you set the bandwidth to 10 Mbps. Even when the maximum experience is set, Teams adapts to low-bandwidth conditions when certain network conditions are detected, depending on the scenario.
 
-The Media bit rate policy does not affect the Teams Web Client.
+The Media bit rate policy doesn't affect the Teams web client.
 
 ## Participants can use video effects
 


### PR DESCRIPTION
We have been asked to add information here stating that the Media bit rate policy does not affect the Teams Web client.

From IcM:  Incident-454340825 Details - IcM (microsofticm.com) ...
"... this feature is initiated to work on desktop clients like some other features, and we haven't implemented it on web clients."