### PR TITLE
Update cloud-intelliframe.md

### DIFF
--- a/Teams/devices/cloud-intelliframe.md
+++ b/Teams/devices/cloud-intelliframe.md
@@ -78,7 +78,6 @@ The following camera models when deployed in Microsoft Teams Rooms on Windows wi
 - Logitech CC3000e
 - Logitech MeetUp
 - Logitech PTZ Pro
-- Logitech PTZ Pro 2
 - Logitech Rally
 - Logitech Webcam C925e
 - Logitech Webcam C920


### PR DESCRIPTION
PTZ Pro 2 Device is no longer an Android Teams Rooms certified device per this document: https://learn.microsoft.com/en-us/microsoftteams/rooms/certified-hardware?tabs=Devices as it no longer has a minimum certified firmware version.