### PR TITLE
Update teams VDI minimum webview2 version

### DIFF
--- a/Teams/new-teams-vdi-requirements-deploy.md
+++ b/Teams/new-teams-vdi-requirements-deploy.md
@@ -42,7 +42,7 @@ In addition, virtual machines must meet the minimum requirements listed here:
 |Requirement |Version|
 |:-----|:-----|
 |Windows|- Windows 10.0.19041 or higher </br>- Windows Server 2019 (10.0.17763) </br>- Windows Server 2022 (10.0.20348) or higher</br>- Windows Server 2016 is NOT supported. Plan upgrades.</br>- WebView2 framework required in Windows Server and Windows 10/11 Multi-User environments|
-|Webview2|Minimum version: 90.0.818.66. Learn more: [Enterprise management of WebView2 Runtimes](/microsoft-edge/webview2/concepts/enterprise)|
+|Webview2|Minimum version: 110.0.1587.63. Learn more: [Enterprise management of WebView2 Runtimes](/microsoft-edge/webview2/concepts/enterprise)|
 |Classic Teams app |Version 1.6.00.4472 or later to see the Try the new Teams toggle. Important: Classic Teams is only a requirement if you want users to be able to switch between classic Teams and new Teams. This prerequisite is optional if you only want your users to see the new Teams client. |
 |Settings |Turn on the **Show Notification Banners** setting in System > Notifications > Microsoft Teams to receive Teams Notifications. |
 |App sideloading enabled |Ensure that sideloading is enabled on every computer you install on. Learn more: Sideload line of business (LOB) apps in Windows client devices |

--- a/Teams/new-teams-vdi-requirements-deploy.md
+++ b/Teams/new-teams-vdi-requirements-deploy.md
@@ -42,7 +42,7 @@ In addition, virtual machines must meet the minimum requirements listed here:
 |Requirement |Version|
 |:-----|:-----|
 |Windows|- Windows 10.0.19041 or higher </br>- Windows Server 2019 (10.0.17763) </br>- Windows Server 2022 (10.0.20348) or higher</br>- Windows Server 2016 is NOT supported. Plan upgrades.</br>- WebView2 framework required in Windows Server and Windows 10/11 Multi-User environments|
-|Webview2|Minimum version: 110.0.1587.63. Learn more: [Enterprise management of WebView2 Runtimes](/microsoft-edge/webview2/concepts/enterprise)|
+|Webview2|Update to the most current version. Learn more: [Enterprise management of WebView2 Runtimes](/microsoft-edge/webview2/concepts/enterprise)|
 |Classic Teams app |Version 1.6.00.4472 or later to see the Try the new Teams toggle. Important: Classic Teams is only a requirement if you want users to be able to switch between classic Teams and new Teams. This prerequisite is optional if you only want your users to see the new Teams client. |
 |Settings |Turn on the **Show Notification Banners** setting in System > Notifications > Microsoft Teams to receive Teams Notifications. |
 |App sideloading enabled |Ensure that sideloading is enabled on every computer you install on. Learn more: Sideload line of business (LOB) apps in Windows client devices |


### PR DESCRIPTION
Update teams VDI minimum webview2 version, aligning with windows wv2 support documentation: https://learn.microsoft.com/en-us/microsoftteams/new-teams-bulk-install-client

Under webview2 110, draggable regions do NOT work, and users will not be able to move teams windows within their monitors;
To provide latest functionalities and performances improvements, we ask to upgrade to latest stable webview2 version