### PR TITLE
Added New Known Issues to Teams New Client

### DIFF
--- a/Teams/new-teams-known-issues.md
+++ b/Teams/new-teams-known-issues.md
@@ -39,6 +39,7 @@ ms.localizationpriority: high
 - If a user closes a TLE session on the web, the next time they open Teams on the web, Teams might try and relaunch the last TLE event the user was in.
 - The app will crash on startup with the error APPLICATION_FAULT_c06d007e_PvDSSource64.ax if the Pleora Technologies eBUS SDK is installed. Update to the latest version of the SDK or uninstall.
 - Town Halls do not yet support web users on Firefox or Safari browsers.
+- Phone calls initiated through a hyperlink or contact card in Outlook Classic are muted.
 
 ## Issues specifically for the new Microsoft Teams for Education
 


### PR DESCRIPTION
Issue exists since September 2023 and is only partially fixed and also not for everyone. Resource: https://answers.microsoft.com/en-us/msteams/forum/all/new-teams-mutes-mic-when-clicking-hyperlinks/4dba15c0-fada-42e5-9940-79463dce4aea