### PR TITLE
Update smartvision-admin.md

### DIFF
--- a/Teams/devices/smartvision-admin.md
+++ b/Teams/devices/smartvision-admin.md
@@ -49,7 +49,7 @@ These Microsoft Teams Rooms devices support Multi-Stream IntelliFrame and people
 
 ### Setting up your certified Multi-Stream IntelliFrame camera to your Microsoft Teams Room
 
-Connect the supplied USB cable to the USB port on your Microsoft Teams Room device.
+Connect the supplied USB 3 cable to a USB 3 port on your Microsoft Teams Rooms compute module. 
 
 > [!Note]
 > Ensure the cable is not pulled tightly or pinched for ideal data transmission and connectivity.


### PR DESCRIPTION
Clarified that USB 3 is required for the camera connection. You can validate this internally as it is a Microsoft requirement. Also mentioned at the bottom of this document: 

https://support.microsoft.com/en-us/office/enhance-hybrid-meetings-with-microsoft-intelliframe-for-teams-rooms-97161377-b746-49dc-992f-97bbf0d590f7

Also, made it clear you connect to the compute module and not to something else, such as the console.