### PR TITLE
Fix file copy script

### DIFF
--- a/Teams/migrate-slack-to-teams.md
+++ b/Teams/migrate-slack-to-teams.md
@@ -242,7 +242,7 @@ foreach ($channel in $channelList) {
     foreach ($folder in $ExportContents)
     {
         #If Channel Name matches..
-        if ($channel.name -eq $folder){
+        if ($channel.name -eq $folder.Name){
             $channelJsons = Get-ChildItem -Path $folder.FullName -File
             Write-Host -ForegroundColor White "$(Get-TimeStamp) Info: Starting to process $($channelJsons.Count) days of content for #$($channel.name)."
             #Start processing the daily JSON for files


### PR DESCRIPTION
`$Folder` is the whole object, and it fails to compare any channel names. This fixes is by comparing `$channel.name` and `$folder.Name`

Tested in an export situation from Slack Pro and now it works for me.