### PR TITLE
Update anonymous-users-in-meetings.md

### DIFF
--- a/Teams/anonymous-users-in-meetings.md
+++ b/Teams/anonymous-users-in-meetings.md
@@ -56,21 +56,21 @@ To allow everyone in your organization to create meetings that allow anonymous u
 To manage anonymous meeting join for your entire organization, follow these steps:
 
 1. Go to the Teams admin center.
-1. Expand **Meetings** > **Meeting policies**.
-1. Under **Participants**, toggle the **Anonymous users can join a meeting** setting **On** or **Off**.
-1. Select **Save**.
+2. Expand **Meetings** > **Meeting settings**.
+3. Under **Participants**, toggle the **Anonymous users can join a meeting** setting **On** or **Off**.
+4. Select **Save**.
 
 ### Per-organizer
 
-To control which users or groups can host meetings that allow anonymous participants, assign this per-organizer meeting policy to each organizer or group. If the organization-wide **Anonymous users can join a meeting** setting is on, you can turn off this policy to prevent specific organizers from creating meetings that allow anonymous users to join.
+To control which users or groups can host meetings that allow anonymous participants, assign a per-organizer meeting policy to each organizer or group. If the organization-wide **Anonymous users can join a meeting** setting is on, you can turn off this policy to prevent specific organizers from creating meetings that allow anonymous users to join.
 
 To manage anonymous meeting join for specific meeting organizers, follow these steps:
 
 1. Go to the Teams admin center.
-1. Expand **Meetings** > **Meeting settings**.
-1. Select an existing policy or create a new one.
-1. Under **Participants**, toggle the **Anonymous users can join a meeting** setting **On** or **Off**.
-1. Select **Save**.
+2. Expand **Meetings** > **Meeting policies**.
+3. Select an existing policy or create a new one.
+4. Under **Participants**, toggle the **Anonymous users can join a meeting** setting **On** or **Off**.
+5. Select **Save**.
 
 Changes to meeting policies might take up to 24 hours to take effect.
 


### PR DESCRIPTION
Corrected org-wide vs per-organizer anon user access, these were backwards. You can't apply meeting SETTINGS to people, you do this with meeting POLICIES. I thought maybe I was just misunderstanding, so I asked co-pilot and it just got stuck in a loop of contradictions. So I'm assuming it's wrong? It's still unclear how the global policy is involved in all of this, is it not just a redundant form of the Meeting Settings? I think the global policy is being phased out, IIRC. If so, maybe a note should be added there 