### PR TITLE
Delete CsTeamsRecordingRolloutPolicy since it is already retired

### DIFF
--- a/Teams/tmr-meeting-recording-change.md
+++ b/Teams/tmr-meeting-recording-change.md
@@ -37,7 +37,7 @@ To learn about your recording policies, see [Teams meeting recording](meeting-re
 
 ### Meetings and events
 
-For **meetings and events**, you can use the per-organizer **`-MeetingRecordingOwnership`** parameter within the PowerShell [**CsTeamsRecordingRolloutPolicy**](/powershell/module/teams/set-csteamsrecordingrolloutpolicy) cmdlet to decide if the recording is saved to the organizer's or recording initiator's OneDrive. This policy applies to the following types of meeting and events:
+For **meetings and events**, the recording saves to the organizer's OneDrive, even if the organizer didn't attend the meeting or event. All recording files are saved to the organizer's OneDrive **Recordings** folder. Co-organizers have the same editing permissions as organizers for recording files. To understand what happens if an organizer doesn't have a OneDrive account, see the **Recording storage for organizers without OneDrive accounts** section in this article. This behavior applies to the following types of meeting and events:
 
 - Automatically recorded meetings
 - Delegate-created meetings
@@ -48,10 +48,6 @@ For **meetings and events**, you can use the per-organizer **`-MeetingRecordingO
 - Recurring meetings
 - Town halls
 - Webinars
-
-If **`-MeetingRecordingOwnership`** is set to **`MeetingOrganizer`**, which is the **default value**, the recording saves to the organizer's OneDrive, even if the organizer didn't attend the meeting or event. All recording files are saved to the organizer's OneDrive **Recordings** folder. Co-organizers have the same editing permissions as organizers for recording files. To understand what happens if an organizer doesn't have a OneDrive account, see the **Recording storage for organizers without OneDrive accounts** section in this article.
-
-If **`-MeetingRecordingOwnership`** is set to **`RecordingInitiator`**, the recording saves to the OneDrive of the user who starts the recording. If the recording initiator doesn't have a OneDrive, the recording is temporarily saved to async media storage.
 
 #### Delegate-created meetings
 


### PR DESCRIPTION
Delete CsTeamsRecordingRolloutPolicy-related content since it is already retired